### PR TITLE
Update install-intellij-libs.sh to work on Ubuntu

### DIFF
--- a/install-intellij-libs.sh
+++ b/install-intellij-libs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # This script will install all files in IntelliJ IDEA's lib/ folder to the local maven .m2 repository. This way we can use them during the build
 #
 # Usage:


### PR DESCRIPTION
Running the install script in ubuntu bombs with:

```
./install-intellij-libs.sh: 28: ./install-intellij-libs.sh: Syntax error: "(" unexpected (expecting "done")
```
