### PR TITLE
Refactor rest clients

### DIFF
--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClient.java
@@ -24,6 +24,7 @@ import com.google.gerrit.extensions.api.changes.RevisionApi;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.google.gerrit.extensions.common.ListChangesOption;
 import com.google.gerrit.extensions.restapi.RestApiException;
+import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
 
 import java.util.EnumSet;
 
@@ -32,21 +33,24 @@ import java.util.EnumSet;
  */
 public class ChangeApiRestClient extends ChangeApi.NotImplemented implements ChangeApi {
 
+    private final GerritRestClient gerritRestClient;
     private final ChangesRestClient changesRestClient;
     private final String id;
 
-    public ChangeApiRestClient(ChangesRestClient changesRestClient, String triplet) {
+    public ChangeApiRestClient(GerritRestClient gerritRestClient,
+                               ChangesRestClient changesRestClient,
+                               String triplet) {
+        this.gerritRestClient = gerritRestClient;
         this.changesRestClient = changesRestClient;
         this.id = triplet;
     }
 
-    public ChangeApiRestClient(ChangesRestClient changesRestClient, int id) {
+    public ChangeApiRestClient(GerritRestClient gerritRestClient,
+                               ChangesRestClient changesRestClient,
+                               int id) {
         this.changesRestClient = changesRestClient;
+        this.gerritRestClient = gerritRestClient;
         this.id = "" + id;
-    }
-
-    public ChangesRestClient getChangesRestClient() {
-        return changesRestClient;
     }
 
     @Override
@@ -56,17 +60,17 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
 
     @Override
     public RevisionApi current() throws RestApiException {
-        return new RevisionApiRestClient(this, "current");
+        return new RevisionApiRestClient(gerritRestClient, this, "current");
     }
 
     @Override
     public RevisionApi revision(int id) throws RestApiException {
-        return new RevisionApiRestClient(this, "" + id);
+        return new RevisionApiRestClient(gerritRestClient, this, "" + id);
     }
 
     @Override
     public RevisionApi revision(String id) throws RestApiException {
-        return new RevisionApiRestClient(this, id);
+        return new RevisionApiRestClient(gerritRestClient, this, id);
     }
 
     @Override
@@ -77,15 +81,15 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
     @Override
     public void abandon(AbandonInput abandonInput) throws RestApiException {
         String request = "/changes/" + id + "/abandon";
-        String json = changesRestClient.getGerritRestClient().getGson().toJson(abandonInput);
-        changesRestClient.getGerritRestClient().postRequest(request, json);
+        String json = gerritRestClient.getGson().toJson(abandonInput);
+        gerritRestClient.postRequest(request, json);
     }
 
     @Override
     public void addReviewer(AddReviewerInput in) throws RestApiException {
         String request = "/changes/" + id + "/reviewers";
-        String json = changesRestClient.getGerritRestClient().getGson().toJson(in);
-        changesRestClient.getGerritRestClient().postRequest(request, json);
+        String json = gerritRestClient.getGson().toJson(in);
+        gerritRestClient.postRequest(request, json);
     }
 
     @Override

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClient.java
@@ -84,20 +84,16 @@ public class ChangesRestClient extends Changes.NotImplemented implements Changes
 
     @Override
     public ChangeApi id(int id) throws RestApiException {
-        return new ChangeApiRestClient(this, id);
+        return new ChangeApiRestClient(gerritRestClient, this, id);
     }
 
     @Override
     public ChangeApi id(String triplet) throws RestApiException {
-        return new ChangeApiRestClient(this, triplet);
+        return new ChangeApiRestClient(gerritRestClient, this, triplet);
     }
 
     @Override
     public ChangeApi id(String project, String branch, String id) throws RestApiException {
-        return new ChangeApiRestClient(this, String.format("%s~%s~%s", project, branch, id));
-    }
-
-    protected GerritRestClient getGerritRestClient() {
-        return gerritRestClient;
+        return new ChangeApiRestClient(gerritRestClient, this, String.format("%s~%s~%s", project, branch, id));
     }
 }

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClient.java
@@ -27,6 +27,7 @@ import com.google.gerrit.extensions.restapi.Url;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
 
 import java.util.List;
 import java.util.Map;
@@ -37,10 +38,14 @@ import java.util.TreeMap;
  */
 public class RevisionApiRestClient extends RevisionApi.NotImplemented implements RevisionApi {
 
+    private final GerritRestClient gerritRestClient;
     private final ChangeApiRestClient changeApiRestClient;
     private final String revision;
 
-    public RevisionApiRestClient(ChangeApiRestClient changeApiRestClient, String revision) {
+    public RevisionApiRestClient(GerritRestClient gerritRestClient,
+                                 ChangeApiRestClient changeApiRestClient,
+                                 String revision) {
+        this.gerritRestClient = gerritRestClient;
         this.changeApiRestClient = changeApiRestClient;
         this.revision = revision;
     }
@@ -48,8 +53,8 @@ public class RevisionApiRestClient extends RevisionApi.NotImplemented implements
     @Override
     public void review(ReviewInput reviewInput) throws RestApiException {
         String request = "/changes/" + changeApiRestClient.id() + "/revisions/" + revision + "/review";
-        String json = changeApiRestClient.getChangesRestClient().getGerritRestClient().getGson().toJson(reviewInput);
-        changeApiRestClient.getChangesRestClient().getGerritRestClient().postRequest(request, json);
+        String json = gerritRestClient.getGson().toJson(reviewInput);
+        gerritRestClient.postRequest(request, json);
     }
 
     @Override
@@ -60,20 +65,20 @@ public class RevisionApiRestClient extends RevisionApi.NotImplemented implements
     @Override
     public void submit(SubmitInput submitInput) throws RestApiException {
         String request = "/changes/" + changeApiRestClient.id() + "/submit";
-        String json = changeApiRestClient.getChangesRestClient().getGerritRestClient().getGson().toJson(submitInput);
-        changeApiRestClient.getChangesRestClient().getGerritRestClient().postRequest(request, json);
+        String json = gerritRestClient.getGson().toJson(submitInput);
+        gerritRestClient.postRequest(request, json);
     }
 
     @Override
     public void setReviewed(String unencodedFilePath) throws RestApiException {
         String url = createReviewedUrl(unencodedFilePath);
-        changeApiRestClient.getChangesRestClient().getGerritRestClient().putRequest(url);
+        gerritRestClient.putRequest(url);
     }
 
     @Override
     public void deleteReviewed(String unencodedFilePath) throws RestApiException {
         String url = createReviewedUrl(unencodedFilePath);
-        changeApiRestClient.getChangesRestClient().getGerritRestClient().deleteRequest(url);
+        gerritRestClient.deleteRequest(url);
     }
 
     public String createReviewedUrl(String unencodedFilePath) {
@@ -87,7 +92,7 @@ public class RevisionApiRestClient extends RevisionApi.NotImplemented implements
     @Override
     public TreeMap<String, List<CommentInfo>> getComments() throws RestApiException {
         String request = "/changes/" + changeApiRestClient.id() + "/revisions/" + revision + "/comments/";
-        JsonElement jsonElement = changeApiRestClient.getChangesRestClient().getGerritRestClient().getRequest(request);
+        JsonElement jsonElement = gerritRestClient.getRequest(request);
         return parseCommentInfos(jsonElement);
     }
 
@@ -108,7 +113,7 @@ public class RevisionApiRestClient extends RevisionApi.NotImplemented implements
     }
 
     private CommentInfo parseSingleCommentInfos(JsonObject result) {
-        Gson gson = changeApiRestClient.getChangesRestClient().getGerritRestClient().getGson();
+        Gson gson = gerritRestClient.getGson();
         return gson.fromJson(result, CommentInfo.class);
     }
 }

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/projects/ProjectsRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/projects/ProjectsRestClient.java
@@ -78,8 +78,4 @@ public class ProjectsRestClient extends Projects.NotImplemented implements Proje
         }
         return projectsParser.parseProjectInfos(result);
     }
-
-    protected GerritRestClient getGerritRestClient() {
-        return gerritRestClient;
-    }
 }

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
@@ -37,10 +37,10 @@ public class ChangeApiRestClientTest {
         GerritRestClient gerritRestClient = getGerritRestClient(
                 "/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/reviewers",
                 "{\"reviewer\":\"jdoe\",\"confirmed\":true}");
-        ChangesRestClient changesRestClient = getChangesRestClient(gerritRestClient);
+        ChangesRestClient changesRestClient = getChangesRestClient();
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(
-                changesRestClient,
+                gerritRestClient, changesRestClient,
                 "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         AddReviewerInput input = new AddReviewerInput();
@@ -57,10 +57,10 @@ public class ChangeApiRestClientTest {
         GerritRestClient gerritRestClient = getGerritRestClient(
                 "/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/reviewers",
                 "{\"reviewer\":\"jdoe\"}");
-        ChangesRestClient changesRestClient = getChangesRestClient(gerritRestClient);
+        ChangesRestClient changesRestClient = getChangesRestClient();
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(
-                changesRestClient,
+                gerritRestClient, changesRestClient,
                 "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         changeApiRestClient.addReviewer("jdoe");
@@ -77,9 +77,8 @@ public class ChangeApiRestClientTest {
         return gerritRestClient;
     }
 
-    private ChangesRestClient getChangesRestClient(GerritRestClient gerritRestClient) {
+    private ChangesRestClient getChangesRestClient() {
         ChangesRestClient changesRestClient = EasyMock.createMock(ChangesRestClient.class);
-        EasyMock.expect(changesRestClient.getGerritRestClient()).andStubReturn(gerritRestClient);
         EasyMock.replay(changesRestClient);
         return changesRestClient;
     }


### PR DESCRIPTION
- pass GerritRestClient to clients instead of "parent" client

Related to issue #56
