### PR TITLE
implement possibility to select diff base in change viewer

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ReviewCommentSink.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ReviewCommentSink.java
@@ -35,13 +35,13 @@ import java.util.Observable;
 public class ReviewCommentSink extends Observable {
     private Multimap<String, CommentHelper> comments = ArrayListMultimap.create();
 
-    public void addComment(String changeId, ReviewInput.CommentInput comment) {
-        comments.put(changeId, new CommentHelper(comment));
+    public void addComment(String changeId, String revisionId, ReviewInput.CommentInput comment) {
+        comments.put(makeKey(changeId, revisionId), new CommentHelper(comment));
         update();
     }
 
-    public Iterable<ReviewInput.CommentInput> getCommentsForChange(String changeId) {
-        Collection<CommentHelper> comments = this.comments.get(changeId);
+    public Iterable<ReviewInput.CommentInput> getCommentsForChange(String changeId, String revisionId) {
+        Collection<CommentHelper> comments = this.comments.get(makeKey(changeId, revisionId));
         return Iterables.transform(comments, new Function<CommentHelper, ReviewInput.CommentInput>() {
             @Override
             public ReviewInput.CommentInput apply(CommentHelper commentHelper) {
@@ -50,19 +50,23 @@ public class ReviewCommentSink extends Observable {
         });
     }
 
-    public void removeCommentForChange(String changeId, Comment commentInput) {
-        boolean removed = comments.get(changeId).remove(new CommentHelper(commentInput));
+    public void removeCommentForChange(String changeId, String revisionId, Comment commentInput) {
+        boolean removed = comments.get(makeKey(changeId, revisionId)).remove(new CommentHelper(commentInput));
         if (removed) {
             update();
         }
     }
 
-    public void removeCommentsForChange(String changeId) {
-        comments.removeAll(changeId);
+    public void removeCommentsForChange(String changeId, String revisionId) {
+        comments.removeAll(makeKey(changeId, revisionId));
     }
 
     private void update() {
         setChanged();
         notifyObservers();
+    }
+
+    private String makeKey(String changeId, String revisionId) {
+        return changeId + '/' + revisionId;
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/git/RevisionFetcher.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/git/RevisionFetcher.java
@@ -1,0 +1,128 @@
+/*
+ *
+ *  * Copyright 2013-2014 Urs Wolfer
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.urswolfer.intellij.plugin.gerrit.git;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.gerrit.extensions.common.FetchInfo;
+import com.google.gerrit.extensions.common.RevisionInfo;
+import com.intellij.openapi.project.Project;
+import com.urswolfer.intellij.plugin.gerrit.rest.GerritUtil;
+import com.urswolfer.intellij.plugin.gerrit.util.NotificationBuilder;
+import com.urswolfer.intellij.plugin.gerrit.util.NotificationService;
+import git4idea.repo.GitRepository;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * This class helps to simultaneously fetch multiple revisions from a git repository.
+ *
+ * @author Thomas Forrer
+ */
+public class RevisionFetcher {
+    private final GerritUtil gerritUtil;
+    private final GerritGitUtil gerritGitUtil;
+    private final NotificationService notificationService;
+    private final Project project;
+    private final GitRepository gitRepository;
+
+    private final List<RevisionInfo> revisionInfoList = Lists.newArrayList();
+    private final List<FetchCallback> fetchCallbacks = Lists.newArrayList();
+
+    public RevisionFetcher(GerritUtil gerritUtil,
+                           GerritGitUtil gerritGitUtil,
+                           NotificationService notificationService,
+                           Project project,
+                           GitRepository gitRepository) {
+        this.gerritUtil = gerritUtil;
+        this.gerritGitUtil = gerritGitUtil;
+        this.notificationService = notificationService;
+        this.project = project;
+        this.gitRepository = gitRepository;
+    }
+
+    public RevisionFetcher addRevision(RevisionInfo revisionInfo) {
+        revisionInfoList.add(revisionInfo);
+        return this;
+    }
+
+    /**
+     * Fetch the changes for the provided revisions.
+     * @param callback the callback will be executed as soon as all revisions have been fetched successfully
+     */
+    public void fetch(final Callable<Void> callback) {
+        for (RevisionInfo revisionInfo : revisionInfoList) {
+            FetchCallback fetchCallback = new FetchCallback(callback);
+            fetchCallbacks.add(fetchCallback);
+            fetchChange(revisionInfo, fetchCallback);
+        }
+    }
+
+    private void fetchChange(RevisionInfo revisionInfo, FetchCallback fetchCallback) {
+        FetchInfo fetchInfo = gerritUtil.getFirstFetchInfo(revisionInfo);
+        if (fetchInfo == null) {
+            notifyError();
+        } else {
+            String ref = fetchInfo.ref;
+            String url = fetchInfo.url;
+            gerritGitUtil.fetchChange(project, gitRepository, url, ref, fetchCallback);
+        }
+    }
+
+    private void notifyError() {
+        NotificationBuilder notification = new NotificationBuilder(
+                project, "Cannot fetch changes",
+                "No fetch information provided. If you are using Gerrit 2.8 or later, " +
+                        "you need to install the plugin 'download-commands' in Gerrit."
+        );
+        notificationService.notifyError(notification);
+    }
+
+    private final class FetchCallback implements Callable<Void> {
+        private final Callable<Void> callback;
+        private boolean returned = false;
+
+        private FetchCallback(Callable<Void> callback) {
+            this.callback = callback;
+        }
+
+        @Override
+        public Void call() throws Exception {
+            try {
+                return null;
+            } finally {
+                returned = true;
+                if (allFetchCallbacksReturned()) {
+                    callback.call();
+                }
+            }
+        }
+
+        private synchronized boolean allFetchCallbacksReturned() {
+            return Iterables.all(fetchCallbacks, new Predicate<FetchCallback>() {
+                @Override
+                public boolean apply(FetchCallback fetchCallback) {
+                    return fetchCallback.returned;
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/GerritUtil.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/GerritUtil.java
@@ -333,7 +333,7 @@ public class GerritUtil {
             public ChangeInfo apply(Void aVoid) {
                 try {
                     EnumSet<ListChangesOption> options = EnumSet.of(
-                            ListChangesOption.CURRENT_REVISION,
+                            ListChangesOption.ALL_REVISIONS,
                             ListChangesOption.MESSAGES,
                             ListChangesOption.LABELS,
                             ListChangesOption.DETAILED_LABELS);
@@ -449,7 +449,11 @@ public class GerritUtil {
 
     public FetchInfo getFirstFetchInfo(ChangeInfo changeDetails) {
         RevisionInfo currentRevision = changeDetails.revisions.get(changeDetails.currentRevision);
-        return Iterables.getFirst(currentRevision.fetch.values(), null);
+        return getFirstFetchInfo(currentRevision);
+    }
+
+    public FetchInfo getFirstFetchInfo(RevisionInfo revisionInfo) {
+        return Iterables.getFirst(revisionInfo.fetch.values(), null);
     }
 
     @SuppressWarnings("UnresolvedPropertyKey")

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritChangeListPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritChangeListPanel.java
@@ -78,8 +78,9 @@ public class GerritChangeListPanel extends JPanel implements TypeSafeDataProvide
             public Component prepareRenderer(TableCellRenderer renderer, int row, int column) {
                 Component component = super.prepareRenderer(renderer, row, column);
                 if (!isRowSelected(row) ) {
+                    ChangeInfo changeInfo = this.getRow(row);
                     Iterable<ReviewInput.CommentInput> commentInputs = GerritChangeListPanel.this.reviewCommentSink
-                            .getCommentsForChange(this.getRow(row).id);
+                            .getCommentsForChange(changeInfo.id, changeInfo.currentRevision);
                     if (!Iterables.isEmpty(commentInputs)) {
                         component.setForeground(JBColor.BLUE);
                     } else {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/ReviewAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/ReviewAction.java
@@ -81,7 +81,8 @@ public class ReviewAction extends AbstractChangeAction {
                 final ReviewInput reviewInput = new ReviewInput();
                 reviewInput.label(label, rating);
 
-                Iterable<ReviewInput.CommentInput> commentInputs = reviewCommentSink.getCommentsForChange(changeDetails.id);
+                Iterable<ReviewInput.CommentInput> commentInputs = reviewCommentSink
+                        .getCommentsForChange(changeDetails.id, changeDetails.currentRevision);
                 for (ReviewInput.CommentInput commentInput : commentInputs) {
                     addComment(reviewInput, commentInput.path, commentInput);
                 }
@@ -112,7 +113,7 @@ public class ReviewAction extends AbstractChangeAction {
                         new Consumer<Void>() {
                             @Override
                             public void consume(Void result) {
-                                reviewCommentSink.removeCommentsForChange(changeDetails.id);
+                                reviewCommentSink.removeCommentsForChange(changeDetails.id, changeDetails.currentRevision);
                                 if (finalSubmitChange) {
                                     submitAction.actionPerformed(anActionEvent);
                                 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/changesbrowser/CommitDiffBuilder.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/changesbrowser/CommitDiffBuilder.java
@@ -1,0 +1,143 @@
+/*
+ *
+ *  * Copyright 2013-2014 Urs Wolfer
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.urswolfer.intellij.plugin.gerrit.ui.changesbrowser;
+
+import com.google.common.base.*;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.intellij.openapi.vcs.VcsException;
+import com.intellij.openapi.vcs.changes.Change;
+import com.intellij.openapi.vcs.changes.ContentRevision;
+import com.intellij.openapi.vcs.changes.SimpleContentRevision;
+import git4idea.history.browser.GitCommit;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class helps to get a list of {@link com.intellij.openapi.vcs.changes.Change}s between two
+ * {@link git4idea.history.browser.GitCommit}s.
+ *
+ * @author Thomas Forrer
+ */
+public class CommitDiffBuilder {
+    private static final Function<Change, String> GET_CHANGED_FILE_PATH = new Function<Change, String>() {
+        @Override
+        public String apply(Change change) {
+            ContentRevision afterRevision = change.getAfterRevision();
+            if (afterRevision != null) {
+                return afterRevision.getFile().getPath();
+            }
+            ContentRevision beforeRevision = change.getBeforeRevision();
+            if (beforeRevision != null) {
+                return beforeRevision.getFile().getPath();
+            }
+            throw new IllegalStateException("Change should have at least one ContentRevision set.");
+        }
+    };
+
+    private static final Predicate<Change> CONTAINS_NO_CHANGE = new Predicate<Change>() {
+        @Override
+        public boolean apply(Change change) {
+            ContentRevision base = change.getBeforeRevision();
+            ContentRevision contentRevision = change.getAfterRevision();
+            if (base == null && contentRevision == null) {
+                return true;
+            }
+            if (base == null) return false;
+            if (contentRevision == null) return false;
+            try {
+                String baseContent = Strings.nullToEmpty(base.getContent());
+                return baseContent.equals(Strings.nullToEmpty(contentRevision.getContent()));
+            } catch (VcsException e) {
+                throw Throwables.propagate(e);
+            }
+        }
+    };
+
+    private final String baseHash;
+    private final String hash;
+    private final Map<String, Change> baseChanges;
+    private final Map<String, Change> changes;
+    private final List<Change> diff = Lists.newArrayList();
+
+    public CommitDiffBuilder(GitCommit base, GitCommit commit) {
+        baseHash = base.getHash().getValue();
+        hash = commit.getHash().getValue();
+        baseChanges = Maps.uniqueIndex(base.getChanges(), GET_CHANGED_FILE_PATH);
+        changes = Maps.uniqueIndex(commit.getChanges(), GET_CHANGED_FILE_PATH);
+    }
+
+    public List<Change> getDiff() throws VcsException {
+        addedFiles();
+        changedFiles();
+        removedFiles();
+        return Lists.newArrayList(Iterables.filter(diff, Predicates.not(CONTAINS_NO_CHANGE)));
+    }
+
+    private void addedFiles() throws VcsException {
+        Sets.SetView<String> addedFiles = Sets.difference(changes.keySet(), baseChanges.keySet());
+        for (String addedFile : addedFiles) {
+            Change change = changes.get(addedFile);
+            ContentRevision beforeRevision = null;
+            if (change.getType().equals(Change.Type.MODIFICATION)) {
+                ContentRevision changeBeforeRevision = change.getBeforeRevision();
+                assert changeBeforeRevision != null;
+                beforeRevision = new SimpleContentRevision(
+                        changeBeforeRevision.getContent(),
+                        changeBeforeRevision.getFile(),
+                        baseHash);
+            }
+            diff.add(new Change(beforeRevision, change.getAfterRevision()));
+        }
+    }
+
+    private void changedFiles() {
+        Sets.SetView<String> changedFiles = Sets.intersection(baseChanges.keySet(), changes.keySet());
+        for (String changedFile : changedFiles) {
+            Change baseChange = baseChanges.get(changedFile);
+            ContentRevision baseRevision = baseChange.getAfterRevision();
+            Change change = changes.get(changedFile);
+            ContentRevision revision = change.getAfterRevision();
+            if (baseRevision != null || revision != null) {
+                diff.add(new Change(baseRevision, revision));
+            }
+        }
+    }
+
+    private void removedFiles() throws VcsException {
+        Sets.SetView<String> removedFiles = Sets.difference(baseChanges.keySet(), changes.keySet());
+        for (String removedFile : removedFiles) {
+            Change baseChange = baseChanges.get(removedFile);
+            ContentRevision afterRevision = null;
+            if (baseChange.getType().equals(Change.Type.MODIFICATION)) {
+                ContentRevision baseChangeBeforeRevision = baseChange.getBeforeRevision();
+                assert baseChangeBeforeRevision != null;
+                afterRevision = new SimpleContentRevision(
+                        baseChangeBeforeRevision.getContent(),
+                        baseChangeBeforeRevision.getFile(),
+                        hash
+                );
+            }
+            diff.add(new Change(baseChange.getAfterRevision(), afterRevision));
+        }
+    }
+}

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/changesbrowser/SelectBaseRevisionAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/changesbrowser/SelectBaseRevisionAction.java
@@ -1,0 +1,129 @@
+/*
+ *
+ *  * Copyright 2013-2014 Urs Wolfer
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  * http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package com.urswolfer.intellij.plugin.gerrit.ui.changesbrowser;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.google.gerrit.extensions.common.ChangeInfo;
+import com.google.gerrit.extensions.common.RevisionInfo;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAwareAction;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Pair;
+import com.intellij.util.Consumer;
+import git4idea.history.wholeTree.BasePopupAction;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Thomas Forrer
+ */
+@SuppressWarnings("ComponentNotRegistered")
+public class SelectBaseRevisionAction extends BasePopupAction {
+
+    private static final String BASE = "Base";
+    private static final Function<Pair<String, RevisionInfo>, String> REVISION_LABEL_FUNCTION = new Function<Pair<String, RevisionInfo>, String>() {
+        @Override
+        public String apply(Pair<String, RevisionInfo> revisionInfo) {
+            return String.format("%s: %s",
+                    revisionInfo.getSecond()._number,
+                    revisionInfo.getFirst().substring(0, 7));
+        }
+    };
+
+    private Optional<ChangeInfo> selectedChange = Optional.absent();
+    private Optional<Pair<String, RevisionInfo>> selectedValue = Optional.absent();
+    private List<Listener> listeners = Lists.newArrayList();
+
+    public SelectBaseRevisionAction(Project project) {
+        super(project, "Diff against:", "Select revision to compare to");
+        updateLabel();
+    }
+
+    @Override
+    protected void createActions(Consumer<AnAction> anActionConsumer) {
+        anActionConsumer.consume(new DumbAwareAction("Base") {
+            @Override
+            public void actionPerformed(AnActionEvent e) {
+                removeSelectedValue();
+                updateLabel();
+            }
+        });
+        if (selectedChange.isPresent()) {
+            Map<String, RevisionInfo> revisions = selectedChange.get().revisions;
+            for (Map.Entry<String, RevisionInfo> entry : revisions.entrySet()) {
+                anActionConsumer.consume(getActionForRevision(entry.getKey(), entry.getValue()));
+            }
+        }
+    }
+
+    public void setSelectedChange(ChangeInfo selectedChange) {
+        this.selectedChange = Optional.of(selectedChange);
+        selectedValue = Optional.absent();
+        updateLabel();
+    }
+
+    public void addRevisionSelectedListener(Listener listener) {
+        this.listeners.add(listener);
+    }
+
+    private DumbAwareAction getActionForRevision(final String commitHash, final RevisionInfo revisionInfo) {
+        final Pair<String, RevisionInfo> infoPair = Pair.create(commitHash, revisionInfo);
+        String actionLabel = REVISION_LABEL_FUNCTION.apply(infoPair);
+        return new DumbAwareAction(actionLabel) {
+            @Override
+            public void actionPerformed(AnActionEvent e) {
+                updateSelectedValue(infoPair);
+                updateLabel();
+            }
+
+            @Override
+            public void update(AnActionEvent e) {
+                e.getPresentation().setEnabled(!commitHash.equals(selectedChange.get().currentRevision));
+            }
+        };
+    }
+
+    private void updateSelectedValue(Pair<String, RevisionInfo> revisionInfo) {
+        selectedValue = Optional.of(revisionInfo);
+        notifyListeners();
+    }
+
+    private void removeSelectedValue() {
+        selectedValue = Optional.absent();
+        notifyListeners();
+    }
+
+    private void notifyListeners() {
+        for (Listener listener : listeners) {
+            listener.revisionSelected(selectedValue);
+        }
+    }
+
+    private void updateLabel() {
+        myLabel.setText(selectedValue.transform(REVISION_LABEL_FUNCTION).or(BASE));
+    }
+
+    public static interface Listener {
+        void revisionSelected(Optional<Pair<String, RevisionInfo>> revisionInfo);
+    }
+}

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/AddCommentAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/AddCommentAction.java
@@ -46,6 +46,7 @@ public class AddCommentAction extends AnAction implements DumbAware {
     private final CommentsDiffTool commentsDiffTool;
     private final ReviewCommentSink reviewCommentSink;
     private final ChangeInfo changeInfo;
+    private final String revisionId;
     private final String filePath;
     private final CommentBalloonBuilder commentBalloonBuilder;
     private final Comment.Side commentSide;
@@ -61,6 +62,7 @@ public class AddCommentAction extends AnAction implements DumbAware {
                             Editor editor,
                             CommentBalloonBuilder commentBalloonBuilder,
                             ChangeInfo changeInfo,
+                            String revisionId,
                             String filePath,
                             Comment.Side commentSide,
                             ReviewInput.CommentInput commentToEdit,
@@ -72,6 +74,7 @@ public class AddCommentAction extends AnAction implements DumbAware {
         this.commentsDiffTool = commentsDiffTool;
         this.reviewCommentSink = reviewCommentSink;
         this.changeInfo = changeInfo;
+        this.revisionId = revisionId;
         this.filePath = filePath;
         this.editor = editor;
         this.commentBalloonBuilder = commentBalloonBuilder;
@@ -109,7 +112,7 @@ public class AddCommentAction extends AnAction implements DumbAware {
 
     private void handleComment(ReviewInput.CommentInput comment, Project project) {
         if (commentToEdit != null) {
-            reviewCommentSink.removeCommentForChange(changeInfo.id, commentToEdit);
+            reviewCommentSink.removeCommentForChange(changeInfo.id, changeInfo.currentRevision, commentToEdit);
             commentsDiffTool.removeComment(editor, lineHighlighter, rangeHighlighter);
         }
 
@@ -117,7 +120,7 @@ public class AddCommentAction extends AnAction implements DumbAware {
             comment.inReplyTo = replyToComment.id;
         }
 
-        reviewCommentSink.addComment(changeInfo.id, comment);
-        commentsDiffTool.addComment(editor, changeInfo, project, comment);
+        reviewCommentSink.addComment(changeInfo.id, revisionId, comment);
+        commentsDiffTool.addComment(editor, changeInfo, revisionId, project, comment);
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/AddCommentActionBuilder.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/AddCommentActionBuilder.java
@@ -21,18 +21,19 @@ public class AddCommentActionBuilder {
 
     public Builder create(CommentsDiffTool commentsDiffTool,
                           ChangeInfo changeInfo,
+                          String revisionId,
                           Editor editor,
                           String filePath,
                           Comment.Side commentSide) {
-        return new Builder().init(commentsDiffTool, changeInfo, editor, filePath, commentSide);
+        return new Builder().init(commentsDiffTool, changeInfo, revisionId, editor, filePath, commentSide);
     }
 
     public class Builder {
-
         private String text;
         private Icon icon;
         private CommentsDiffTool commentsDiffTool;
         private ChangeInfo changeInfo;
+        private String revisionId;
         private Editor editor;
         private String filePath;
         private Comment.Side commentSide;
@@ -43,11 +44,13 @@ public class AddCommentActionBuilder {
 
         private Builder init(CommentsDiffTool commentsDiffTool,
                              ChangeInfo changeInfo,
+                             String revisionId,
                              Editor editor,
                              String filePath,
                              Comment.Side commentSide) {
             this.commentsDiffTool = commentsDiffTool;
             this.changeInfo = changeInfo;
+            this.revisionId = revisionId;
             this.editor = editor;
             this.filePath = filePath;
             this.commentSide = commentSide;
@@ -80,7 +83,7 @@ public class AddCommentActionBuilder {
 
         public AddCommentAction get() {
             return new AddCommentAction(text, icon, commentsDiffTool, reviewCommentSink, editor, commentBalloonBuilder,
-                    changeInfo, filePath, commentSide, commentToEdit, lineHighlighter, rangeHighlighter, replyToComment);
+                    changeInfo, revisionId, filePath, commentSide, commentToEdit, lineHighlighter, rangeHighlighter, replyToComment);
         }
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/CommentDoneAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/CommentDoneAction.java
@@ -38,12 +38,14 @@ public class CommentDoneAction extends AnAction implements DumbAware {
     private final ReviewCommentSink reviewCommentSink;
     private final Comment fileComment;
     private final ChangeInfo changeInfo;
+    private final String revisionId;
 
     public CommentDoneAction(Editor editor,
                              CommentsDiffTool commentsDiffTool,
                              ReviewCommentSink reviewCommentSink,
                              Comment fileComment,
-                             ChangeInfo changeInfo) {
+                             ChangeInfo changeInfo,
+                             String revisionId) {
         super("Done", null, AllIcons.Actions.Checked);
 
         this.editor = editor;
@@ -51,6 +53,7 @@ public class CommentDoneAction extends AnAction implements DumbAware {
         this.reviewCommentSink = reviewCommentSink;
         this.fileComment = fileComment;
         this.changeInfo = changeInfo;
+        this.revisionId = revisionId;
     }
 
     @Override
@@ -62,9 +65,9 @@ public class CommentDoneAction extends AnAction implements DumbAware {
         comment.path = fileComment.path;
         comment.side = fileComment.side;
 
-        reviewCommentSink.addComment(changeInfo.id, comment);
+        reviewCommentSink.addComment(changeInfo.id, revisionId, comment);
 
         Project project = e.getData(PlatformDataKeys.PROJECT);
-        commentsDiffTool.addComment(editor, changeInfo, project, comment);
+        commentsDiffTool.addComment(editor, changeInfo, revisionId, project, comment);
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/CommentGutterIconRenderer.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/CommentGutterIconRenderer.java
@@ -47,6 +47,7 @@ public class CommentGutterIconRenderer extends GutterIconRenderer {
     private final AddCommentActionBuilder addCommentActionBuilder;
     private final Comment fileComment;
     private final ChangeInfo changeInfo;
+    private final String revisionId;
     private final RangeHighlighter lineHighlighter;
     private final RangeHighlighter rangeHighlighter;
 
@@ -56,12 +57,14 @@ public class CommentGutterIconRenderer extends GutterIconRenderer {
                                      AddCommentActionBuilder addCommentActionBuilder,
                                      Comment fileComment,
                                      ChangeInfo changeInfo,
+                                     String revisionId,
                                      RangeHighlighter lineHighlighter,
                                      RangeHighlighter rangeHighlighter) {
         this.commentsDiffTool = commentsDiffTool;
         this.fileComment = fileComment;
         this.reviewCommentSink = reviewCommentSink;
         this.changeInfo = changeInfo;
+        this.revisionId = revisionId;
         this.lineHighlighter = lineHighlighter;
         this.editor = editor;
         this.rangeHighlighter = rangeHighlighter;
@@ -133,7 +136,7 @@ public class CommentGutterIconRenderer extends GutterIconRenderer {
         DefaultActionGroup actionGroup = new DefaultActionGroup();
         if (isNewCommentFromMyself()) {
             AddCommentAction commentAction = addCommentActionBuilder
-                    .create(commentsDiffTool, changeInfo, editor, fileComment.path, fileComment.side)
+                    .create(commentsDiffTool, changeInfo, revisionId, editor, fileComment.path, fileComment.side)
                     .withText("Edit")
                     .withIcon(AllIcons.Toolwindows.ToolWindowMessages)
                     .update((ReviewInput.CommentInput) fileComment, lineHighlighter, rangeHighlighter)
@@ -146,7 +149,7 @@ public class CommentGutterIconRenderer extends GutterIconRenderer {
             actionGroup.add(removeCommentAction);
         } else {
             AddCommentAction commentAction = addCommentActionBuilder
-                    .create(commentsDiffTool, changeInfo, editor, fileComment.path, fileComment.side)
+                    .create(commentsDiffTool, changeInfo, revisionId, editor, fileComment.path, fileComment.side)
                     .withText("Reply")
                     .withIcon(AllIcons.Actions.Back)
                     .reply(fileComment)
@@ -154,7 +157,7 @@ public class CommentGutterIconRenderer extends GutterIconRenderer {
             actionGroup.add(commentAction);
 
             CommentDoneAction commentDoneAction = new CommentDoneAction(
-                    editor, commentsDiffTool, reviewCommentSink, fileComment, changeInfo);
+                    editor, commentsDiffTool, reviewCommentSink, fileComment, changeInfo, revisionId);
             actionGroup.add(commentDoneAction);
         }
         return actionGroup;

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/RemoveCommentAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/RemoveCommentAction.java
@@ -60,7 +60,7 @@ public class RemoveCommentAction extends AnAction implements DumbAware {
 
     @Override
     public void actionPerformed(AnActionEvent e) {
-        reviewCommentSink.removeCommentForChange(changeInfo.id, comment);
+        reviewCommentSink.removeCommentForChange(changeInfo.id, changeInfo.currentRevision, comment);
         commentsDiffTool.removeComment(editor, lineHighlighter, rangeHighlighter);
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/GerritDataKeys.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/GerritDataKeys.java
@@ -16,8 +16,11 @@
 
 package com.urswolfer.intellij.plugin.gerrit.util;
 
+import com.google.common.base.Optional;
 import com.google.gerrit.extensions.common.ChangeInfo;
+import com.google.gerrit.extensions.common.RevisionInfo;
 import com.intellij.openapi.actionSystem.DataKey;
+import com.intellij.openapi.util.Pair;
 import com.urswolfer.intellij.plugin.gerrit.ReviewCommentSink;
 import com.urswolfer.intellij.plugin.gerrit.ui.GerritToolWindow;
 
@@ -26,6 +29,7 @@ import com.urswolfer.intellij.plugin.gerrit.ui.GerritToolWindow;
  */
 public interface GerritDataKeys {
     DataKey<ChangeInfo> CHANGE = DataKey.create("gerrit.Change");
+    DataKey<Optional<Pair<String, RevisionInfo>>> BASE_REVISION = DataKey.create("gerrit.Change.BaseRevision");
     DataKey<ReviewCommentSink> REVIEW_COMMENT_SINK = DataKey.create("gerrit.ReviewCommentSink");
     DataKey<GerritToolWindow> TOOL_WINDOW = DataKey.create("gerrit.ToolWindow");
 }


### PR DESCRIPTION
- previous revisions or the change's base can be selected as
  a diff base
- comments in RevisionCommentSink are now linked to a
  revision as well as the change
- related to issue #22
