### PR TITLE
fix concurrency issue when selecting a change from the list

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/RepositoryChangesBrowserProvider.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/RepositoryChangesBrowserProvider.java
@@ -139,15 +139,18 @@ public class RepositoryChangesBrowserProvider {
         }
 
         protected void setSelectedChange(ChangeInfo changeInfo) {
+            selectedChange = changeInfo;
             gerritUtil.getChangeDetails(changeInfo._number, project, new Consumer<ChangeInfo>() {
                 @Override
                 public void consume(ChangeInfo changeDetails) {
-                    selectedChange = changeDetails;
-                    baseRevision = Optional.absent();
-                    updateChangesBrowser();
-                    selectBaseRevisionAction.setSelectedChange(selectedChange);
-                    for (GerritChangeNodeDecorator decorator : changeNodeDecorators) {
-                        decorator.onChangeSelected(project, selectedChange);
+                    if (selectedChange.changeId.equals(changeDetails.changeId)) {
+                        selectedChange = changeDetails;
+                        baseRevision = Optional.absent();
+                        selectBaseRevisionAction.setSelectedChange(selectedChange);
+                        for (GerritChangeNodeDecorator decorator : changeNodeDecorators) {
+                            decorator.onChangeSelected(project, selectedChange);
+                        }
+                        updateChangesBrowser();
                     }
                 }
             });


### PR DESCRIPTION
When selecting two changes from the changes list shortly after each
other, the changes browser on the right may display the wrong change
because fetching the git commit may take longer for the first selected
change. The changes from the second selected change are then wrongly
overwritten by the first change. This commit fixes the wrong behaviour.
