### PR TITLE
Fixed compile errors on IntelliJ 14 EAP

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
@@ -251,6 +251,15 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
         }
     }
 
+    public void forgetPassword(final String key) {
+        try {
+            PasswordSafe.getInstance().removePassword(null, GerritSettings.class, key);
+            passwordChanged = true;
+        } catch (PasswordSafeException e) {
+            log.info("Couldn't forget password for key [" + key + "]", e);
+        }
+    }
+
     public void setHost(final String host) {
         this.host = host;
     }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/extension/GerritHttpAuthDataProvider.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/extension/GerritHttpAuthDataProvider.java
@@ -22,7 +22,7 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.AuthData;
 import com.urswolfer.intellij.plugin.gerrit.GerritModule;
 import com.urswolfer.intellij.plugin.gerrit.GerritSettings;
-import git4idea.jgit.GitHttpAuthDataProvider;
+import git4idea.remote.GitHttpAuthDataProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -49,6 +49,11 @@ public class GerritHttpAuthDataProvider implements GitHttpAuthDataProvider {
         return new AuthData(gerritSettings.getLogin(), gerritSettings.getPassword());
     }
 
+    @Override
+    public void forgetPassword(@NotNull String key) {
+        gerritSettings.forgetPassword(key);
+    }
+
     public static final class Proxy implements GitHttpAuthDataProvider {
         private final GitHttpAuthDataProvider delegate;
 
@@ -60,6 +65,11 @@ public class GerritHttpAuthDataProvider implements GitHttpAuthDataProvider {
         @Override
         public AuthData getAuthData(@NotNull String url) {
             return delegate.getAuthData(url);
+        }
+
+        @Override
+        public void forgetPassword(@NotNull String key) {
+            delegate.forgetPassword(key);
         }
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/git/GerritGitUtil.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/git/GerritGitUtil.java
@@ -204,7 +204,8 @@ public class GerritGitUtil {
             String description = "Some untracked working tree files would be overwritten by cherry-pick.<br/>" +
                     "Please move, remove or add them before you can cherry-pick. <a href='view'>View them</a>";
 
-            UntrackedFilesNotifier.notifyUntrackedFilesOverwrittenBy(project, untrackedFilesDetector.getFiles(),
+            UntrackedFilesNotifier.notifyUntrackedFilesOverwrittenBy(project, repository.getRoot(),
+                    untrackedFilesDetector.getRelativeFilePaths(),
                     "cherry-pick", description);
             return false;
         } else if (localChangesOverwrittenDetector.hasHappened()) {


### PR DESCRIPTION
Hey Urs,

_Feel free to abandon this pull request if you already were working on this locally or if I did it wrong. I'm only sending this in case it can save you a few minutes of time._

I recently downloaded the IDEA 14 EAP and your gerrit plugin failed to load on it. Therefore, I forked your project and cleaned up the compile errors.

There really wasn't that much that changed, actually:
- `GitHttpAuthDataProvider` moved into a new package
- `GitHttpAuthDataProvider` added a new method to its interface, `forgetPassword`
- `UntrackedFilesNotifier.notifyUntrackedFilesOverwrittenBy` changed its API

I guessed at what should be done to fix it, but I'm not sure if I did it the right way, or even how to cause the code to run those lines so I could make sure they wouldn't explode, but I thought I'd put it out there for review anyway, and you could either take over at this point or you can advise me how to rewrite this.

Finally, I based this branch off of intellij13, but of course, you'd want to pull these changes into a new intellij14 branch. Not sure if github makes it easy to do that or not...
