### PR TITLE
fix a bug in LoadChangesProxy when no changes are returned

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/LoadChangesProxy.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/LoadChangesProxy.java
@@ -68,10 +68,10 @@ public class LoadChangesProxy {
                         hasMore = lastChangeInfo._moreChanges != null && lastChangeInfo._moreChanges;
                         sortkey = lastChangeInfo._sortkey;
                         changes.addAll(changeInfos);
-                        consumer.consume(changeInfos);
                     } else {
                         hasMore = false;
                     }
+                    consumer.consume(changeInfos);
                     lock.unlock();
                 }
             };


### PR DESCRIPTION
changes list always needs to be consumed by the changes panel, even
when no changes are returned, since it might have been the first call to
#getNextPage that didn't return any results. previously the changes returned
from the last request would remain visible in the changes list.