### PR TITLE
Fixing squid: S1118 Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/Version.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/Version.java
@@ -22,10 +22,11 @@ import com.intellij.openapi.extensions.PluginId;
 /**
  * @author Urs Wolfer
  */
-public class Version {
+public final class Version {
 
     private static final String PLUGIN_VERSION = PluginManager.getPlugin(PluginId.getId("com.urswolfer.intellij.plugin.gerrit")).getVersion();
 
+    private Version() {}
     public static String get() {
         return PLUGIN_VERSION;
     }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/RangeUtils.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/RangeUtils.java
@@ -26,7 +26,10 @@ import java.io.IOException;
 /**
  * @author Urs Wolfer
  */
-public class RangeUtils {
+public final class RangeUtils {
+
+    private RangeUtils() {}
+
     public static Comment.Range textOffsetToRange(CharSequence charsSequence, int start, int end) {
         int startLine = 1;
         int startOffset = -1;

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/TextToHtml.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/TextToHtml.java
@@ -21,7 +21,9 @@ import com.urswolfer.intellij.plugin.gerrit.util.safehtml.SafeHtmlBuilder;
 /**
  * @author Urs Wolfer
  */
-public class TextToHtml {
+public final class TextToHtml {
+
+    private TextToHtml() {}
 
     /**
      * Converts plain text formatted with wiki-like syntax to HTML.

--- a/src/main/java/icons/GerritIcons.java
+++ b/src/main/java/icons/GerritIcons.java
@@ -29,7 +29,10 @@ import javax.swing.*;
  *
  * @author Urs Wolfer
  */
-public class GerritIcons {
+public final class GerritIcons {
+
+    private GerritIcons() {}
+
     private static Icon load(String path) {
         return IconLoader.getIcon(path, GerritIcons.class);
     }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1118 - “Utility classes should not have public constructors ”. 
This PR will remove 120min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1118
 Please let me know if you have any questions.
Fevzi Ozgul
