### PR TITLE
Fixing squid: S1226 Method parameters, caught exceptions and foreach variables should not be reassigned

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/git/GerritGitUtil.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/git/GerritGitUtil.java
@@ -368,10 +368,11 @@ public class GerritGitUtil {
 
         @Override
         public void onLineAvailable(String s, Key key) {
+            String sLocal = s;
             if ( s.startsWith("\t") ) {
-                s = "<b>" + s.substring(1) + "</b>";
+                sLocal = "<b>" + s.substring(1) + "</b>";
             }
-            messages.add(s);
+            messages.add(sLocal);
         }
 
         @Override

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
@@ -71,13 +71,13 @@ public class GerritPushExtensionPanel extends JPanel {
             initialized = false;
             gerritPushTargetPanels.clear();
         }
-
+        String branchLocal = branch;
         if (branch != null) {
-            branch = branch.replaceAll("^refs/(for|drafts)/", "");
-            branch = branch.replaceAll("%.*$", "");
+            branchLocal = branch.replaceAll("^refs/(for|drafts)/", "");
+            branchLocal = branchLocal.replaceAll("%.*$", "");
         }
 
-        gerritPushTargetPanels.put(gerritPushTargetPanel, branch);
+        gerritPushTargetPanels.put(gerritPushTargetPanel, branchLocal);
     }
 
     public void initialized() {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/GerritUtil.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/GerritUtil.java
@@ -287,10 +287,11 @@ public class GerritUtil {
     }
 
     public void getChangesForProject(String query, final Project project, final Consumer<LoadChangesProxy> consumer) {
+        String queryLocal = query;
         if (!gerritSettings.getListAllChanges()) {
-            query = appendQueryStringForProject(project, query);
+            queryLocal = appendQueryStringForProject(project, query);
         }
-        getChanges(query, project, consumer);
+        getChanges(queryLocal, project, consumer);
     }
 
     public void getChanges(final String query, final Project project, final Consumer<LoadChangesProxy> consumer) {
@@ -355,9 +356,10 @@ public class GerritUtil {
     }
 
     private String appendQueryStringForProject(Project project, String query) {
+        String queryLocal;
         String projectQueryPart = getProjectQueryPart(project);
-        query = Joiner.on('+').skipNulls().join(Strings.emptyToNull(query), Strings.emptyToNull(projectQueryPart));
-        return query;
+        queryLocal = Joiner.on('+').skipNulls().join(Strings.emptyToNull(query), Strings.emptyToNull(projectQueryPart));
+        return queryLocal;
     }
 
     private String getProjectQueryPart(Project project) {
@@ -400,11 +402,12 @@ public class GerritUtil {
     }
 
     private String getProjectName(String repositoryUrl, String url) {
+        String repositoryUrlLocal = repositoryUrl;
         if (!repositoryUrl.endsWith("/")) {
-            repositoryUrl = repositoryUrl + "/";
+            repositoryUrlLocal = repositoryUrl + "/";
         }
 
-        String basePath = UrlUtils.createUriFromGitConfigString(repositoryUrl).getPath();
+        String basePath = UrlUtils.createUriFromGitConfigString(repositoryUrlLocal).getPath();
         String path = UrlUtils.createUriFromGitConfigString(url).getPath();
 
         if (path.length() >= basePath.length()) {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/ReviewActionGroup.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/ReviewActionGroup.java
@@ -102,9 +102,10 @@ public class ReviewActionGroup extends ActionGroup {
                     values, new Function<String, Integer>() {
                         @Override
                         public Integer apply(String v) {
-                            v = v.trim();
-                            if (v.charAt(0) == '+') v = v.substring(1); // required for Java 6 support
-                            return Integer.valueOf(v);
+                            String vLocal;
+                            vLocal = v.trim();
+                            if (vLocal.charAt(0) == '+') vLocal = vLocal.substring(1); // required for Java 6 support
+                            return Integer.valueOf(vLocal);
                         }
                     }));
                 Collections.sort(intValues);

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/TextToHtml.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/TextToHtml.java
@@ -30,8 +30,9 @@ public class TextToHtml {
         if (!text.contains("\n")) {
             return text;
         }
-        text = SafeHtmlBuilder.asis(text).wikify().asString();
-        text = text.replace("</p><p>", "</p><br/><p>"); // otherwise paragraph breaks are not visible in IntelliJ...
-        return text;
+        String textLocal;
+        textLocal = SafeHtmlBuilder.asis(text).wikify().asString();
+        textLocal = textLocal.replace("</p><p>", "</p><br/><p>"); // otherwise paragraph breaks are not visible in IntelliJ...
+        return textLocal;
     }
 }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1226 - “Method parameters, caught exceptions and foreach variables should not be reassigned ”.  This PR will remove 65 min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1226
 Please let me know if you have any questions.
 Fevzi Ozgul
