### PR TITLE
Fixing squid: S2131  Primitives should not be boxed just for "String" conversion

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
@@ -77,13 +77,13 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
         final Element element = new Element(GERRIT_SETTINGS_TAG);
         element.setAttribute(LOGIN, (getLogin() != null ? getLogin() : ""));
         element.setAttribute(HOST, (getHost() != null ? getHost() : ""));
-        element.setAttribute(LIST_ALL_CHANGES, "" + getListAllChanges());
-        element.setAttribute(AUTOMATIC_REFRESH, "" + getAutomaticRefresh());
+        element.setAttribute(LIST_ALL_CHANGES, Boolean.toString(getListAllChanges()));
+        element.setAttribute(AUTOMATIC_REFRESH, Boolean.toString(getAutomaticRefresh()));
         element.setAttribute(REFRESH_TIMEOUT, "" + getRefreshTimeout());
-        element.setAttribute(REVIEW_NOTIFICATIONS, "" + getReviewNotifications());
-        element.setAttribute(PUSH_TO_GERRIT, "" + getPushToGerrit());
-        element.setAttribute(SHOW_CHANGE_NUMBER_COLUMN, "" + getShowChangeNumberColumn());
-        element.setAttribute(SHOW_CHANGE_ID_COLUMN, "" + getShowChangeIdColumn());
+        element.setAttribute(REVIEW_NOTIFICATIONS, Boolean.toString(getReviewNotifications()));
+        element.setAttribute(PUSH_TO_GERRIT, Boolean.toString(getPushToGerrit()));
+        element.setAttribute(SHOW_CHANGE_NUMBER_COLUMN, Boolean.toString(getShowChangeNumberColumn()));
+        element.setAttribute(SHOW_CHANGE_ID_COLUMN, Boolean.toString(getShowChangeIdColumn()));
         return element;
     }
 


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2131 - “Primitives should not be boxed just for ""String"" conversion”. 
 This PR will remove 35min of TD.
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2131
 Please let me know if you have any questions.
 Fevzi Ozgul
