### PR TITLE
fix gerrit project name calculation

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/GerritUtil.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/GerritUtil.java
@@ -432,7 +432,7 @@ public class GerritUtil {
         String basePath = UrlUtils.createUriFromGitConfigString(repositoryUrl).getPath();
         String path = UrlUtils.createUriFromGitConfigString(url).getPath();
 
-        if (path.length() >= basePath.length()) {
+        if (path.length() >= basePath.length() && path.startsWith(basePath)) {
             path = path.substring(basePath.length());
         }
 
@@ -440,6 +440,10 @@ public class GerritUtil {
 
         if (path.endsWith("/")) {
             path = path.substring(0, path.length() - 1);
+        }
+        // gerrit project names usually dont start with a slash
+        if (path.startsWith("/")) {
+            path = path.substring(1, path.length());
         }
 
         return path;

--- a/src/test/java/com/urswolfer/intellij/plugin/gerrit/rest/GerritUtilTest.java
+++ b/src/test/java/com/urswolfer/intellij/plugin/gerrit/rest/GerritUtilTest.java
@@ -130,6 +130,13 @@ public class GerritUtilTest {
                         "http://gerrit.server/r/project/blah/test.git"
                 ));
 
+        // specific case where gerrit URL is provided via HTTP but git is configured to use ssh
+        Assert.assertEquals("project/blah",
+                getProjectName.invoke(gerritUtil,
+                        "http://gerrit.server/gerrit",
+                        "ssh://git@gerrit.server:29418/project/blah"
+                ));
+
         // should not fail with an StringIndexOutOfBoundsException
         Assert.assertEquals("",
                 getProjectName.invoke(gerritUtil,


### PR DESCRIPTION
- when a gerrit host has a path and git uses ssh, then the project name
  calculation was off resulting in a REST query looking for an invalid
  project name
