### PR TITLE
Adds (optional) topic column to changes list

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
@@ -59,6 +59,7 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
     private static final String PUSH_TO_GERRIT = "PushToGerrit";
     private static final String SHOW_CHANGE_NUMBER_COLUMN = "ShowChangeNumberColumn";
     private static final String SHOW_CHANGE_ID_COLUMN = "ShowChangeIdColumn";
+    private static final String SHOW_TOPIC_COLUMN = "ShowTopicColumn";
     private static final String GERRIT_SETTINGS_PASSWORD_KEY = "GERRIT_SETTINGS_PASSWORD_KEY";
 
     private String login;
@@ -70,6 +71,7 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
     private boolean pushToGerrit;
     private boolean showChangeNumberColumn;
     private boolean showChangeIdColumn;
+    private boolean showTopicColumn;
 
     private Logger log;
 
@@ -84,6 +86,7 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
         element.setAttribute(PUSH_TO_GERRIT, Boolean.toString(getPushToGerrit()));
         element.setAttribute(SHOW_CHANGE_NUMBER_COLUMN, Boolean.toString(getShowChangeNumberColumn()));
         element.setAttribute(SHOW_CHANGE_ID_COLUMN, Boolean.toString(getShowChangeIdColumn()));
+        element.setAttribute(SHOW_TOPIC_COLUMN, Boolean.toString(getShowTopicColumn()));
         return element;
     }
 
@@ -100,6 +103,7 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
             setPushToGerrit(getBooleanValue(element, PUSH_TO_GERRIT));
             setShowChangeNumberColumn(getBooleanValue(element, SHOW_CHANGE_NUMBER_COLUMN));
             setShowChangeIdColumn(getBooleanValue(element, SHOW_CHANGE_ID_COLUMN));
+            setShowTopicColumn(getBooleanValue(element, SHOW_TOPIC_COLUMN));
         } catch (Exception e) {
             log.error("Error happened while loading gerrit settings: " + e);
         }
@@ -230,6 +234,14 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
 
     public void setShowChangeIdColumn(boolean showChangeIdColumn) {
         this.showChangeIdColumn = showChangeIdColumn;
+    }
+
+    public boolean getShowTopicColumn() {
+        return showTopicColumn;
+    }
+
+    public void setShowTopicColumn(boolean showTopicColumn) {
+        this.showTopicColumn = showTopicColumn;
     }
 
     public void setLog(Logger log) {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritChangeListPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritChangeListPanel.java
@@ -232,6 +232,7 @@ public class GerritChangeListPanel extends JPanel implements TypeSafeDataProvide
     private ColumnInfo[] generateColumnsInfo(@NotNull List<ChangeInfo> changes) {
         ItemAndWidth number = new ItemAndWidth("", 0);
         ItemAndWidth hash = new ItemAndWidth("", 0);
+        ItemAndWidth topic = new ItemAndWidth("", 0);
         ItemAndWidth subject = new ItemAndWidth("", 0);
         ItemAndWidth status = new ItemAndWidth("", 0);
         ItemAndWidth author = new ItemAndWidth("", 0);
@@ -242,6 +243,7 @@ public class GerritChangeListPanel extends JPanel implements TypeSafeDataProvide
         for (ChangeInfo change : changes) {
             number = getMax(number, getNumber(change));
             hash = getMax(hash, getHash(change));
+            topic = getMax(topic, getTopic(change));
             subject = getMax(subject, getShortenedSubject(change));
             status = getMax(status, getStatus(change));
             author = getMax(author, getOwner(change));
@@ -279,6 +281,18 @@ public class GerritChangeListPanel extends JPanel implements TypeSafeDataProvide
                 }
             );
         }
+        boolean showTopicColumn = gerritSettings.getShowTopicColumn();
+        if (showTopicColumn) {
+            columnList.add(
+                new GerritChangeColumnInfo("Topic", topic.item) {
+                    @Override
+                    public String valueOf(ChangeInfo change) {
+                        return getTopic(change);
+                    }
+                }
+            );
+        }
+
         columnList.add(
             new GerritChangeColumnInfo("Subject", subject.item) {
                 @Override
@@ -382,6 +396,10 @@ public class GerritChangeListPanel extends JPanel implements TypeSafeDataProvide
 
     private static String getHash(ChangeInfo change) {
         return change.changeId.substring(0, 9);
+    }
+
+    private static String getTopic(ChangeInfo change) {
+        return change.topic;
     }
 
     private static String getShortenedSubject(ChangeInfo change) {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritSettingsConfigurable.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritSettingsConfigurable.java
@@ -75,7 +75,8 @@ public class GerritSettingsConfigurable implements SearchableConfigurable, VcsCo
                 !Comparing.equal(gerritSettings.getReviewNotifications(), settingsPane.getReviewNotifications()) ||
                 !Comparing.equal(gerritSettings.getPushToGerrit(), settingsPane.getPushToGerrit()) ||
                 !Comparing.equal(gerritSettings.getShowChangeNumberColumn(), settingsPane.getShowChangeNumberColumn()) ||
-                !Comparing.equal(gerritSettings.getShowChangeIdColumn(), settingsPane.getShowChangeIdColumn()));
+                !Comparing.equal(gerritSettings.getShowChangeIdColumn(), settingsPane.getShowChangeIdColumn()) ||
+                !Comparing.equal(gerritSettings.getShowTopicColumn(), settingsPane.getShowTopicColumn()));
     }
 
     private boolean isPasswordModified() {
@@ -97,6 +98,7 @@ public class GerritSettingsConfigurable implements SearchableConfigurable, VcsCo
             gerritSettings.setPushToGerrit(settingsPane.getPushToGerrit());
             gerritSettings.setShowChangeNumberColumn(settingsPane.getShowChangeNumberColumn());
             gerritSettings.setShowChangeIdColumn(settingsPane.getShowChangeIdColumn());
+            gerritSettings.setShowTopicColumn(settingsPane.getShowTopicColumn());
 
             gerritUpdatesNotificationComponent.handleConfigurationChange();
         }
@@ -116,6 +118,7 @@ public class GerritSettingsConfigurable implements SearchableConfigurable, VcsCo
             settingsPane.setPushToGerrit(gerritSettings.getPushToGerrit());
             settingsPane.setShowChangeNumberColumn(gerritSettings.getShowChangeNumberColumn());
             settingsPane.setShowChangeIdColumn(gerritSettings.getShowChangeIdColumn());
+            settingsPane.setShowTopicColumn(gerritSettings.getShowTopicColumn());
         }
     }
 

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/SettingsPanel.form
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/SettingsPanel.form
@@ -3,7 +3,7 @@
   <grid id="9dc44" binding="pane" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="563" height="400"/>
+      <xy x="20" y="20" width="563" height="425"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -100,7 +100,7 @@
               </component>
             </children>
           </grid>
-          <grid id="d87b1" binding="settingsPane" layout-manager="GridLayoutManager" row-count="6" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="d87b1" binding="settingsPane" layout-manager="GridLayoutManager" row-count="7" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
               <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
@@ -189,6 +189,14 @@
                 </constraints>
                 <properties>
                   <text value="Show Change ID Column in List"/>
+                </properties>
+              </component>
+              <component id="f961e" class="javax.swing.JCheckBox" binding="showTopicColumnCheckBox">
+                <constraints>
+                  <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Show Topic Column in List"/>
                 </properties>
               </component>
             </children>

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/SettingsPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/SettingsPanel.java
@@ -58,6 +58,7 @@ public class SettingsPanel {
     private JCheckBox pushToGerritCheckbox;
     private JCheckBox showChangeNumberColumnCheckBox;
     private JCheckBox showChangeIdColumnCheckBox;
+    private JCheckBox showTopicColumnCheckBox;
 
     private boolean passwordModified;
 
@@ -226,6 +227,14 @@ public class SettingsPanel {
 
     public void setShowChangeIdColumn(final boolean showChangeIdColumn) {
         showChangeIdColumnCheckBox.setSelected(showChangeIdColumn);
+    }
+
+    public boolean getShowTopicColumn() {
+        return showTopicColumnCheckBox.isSelected();
+    }
+
+    public void setShowTopicColumn(final boolean showTopicColumn) {
+        showTopicColumnCheckBox.setSelected(showTopicColumn);
     }
 
     public boolean isPasswordModified() {


### PR DESCRIPTION
Adds optional "Topic" column to the changes list in the gerrit toolwindow.
Must be enabled via "[ ] Show Topic Column" in gerrit settings, similar to "Changes ID" and "Changed #" columns.