### PR TITLE
Match gerrit url to both url and pushurl.

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/git/GerritGitUtil.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/git/GerritGitUtil.java
@@ -132,7 +132,10 @@ public class GerritGitUtil {
     public Optional<GitRemote> getRemoteForChange(Project project, GitRepository gitRepository, FetchInfo fetchInfo) {
         String url = fetchInfo.url;
         for (GitRemote remote : gitRepository.getRemotes()) {
-            for (String repositoryUrl : remote.getUrls()) {
+            List<String> repositoryUrls = new ArrayList<String>();
+            repositoryUrls.addAll(remote.getUrls());
+            repositoryUrls.addAll(remote.getPushUrls());
+            for (String repositoryUrl : repositoryUrls) {
                 if (UrlUtils.urlHasSameHost(repositoryUrl, url)
                     || UrlUtils.urlHasSameHost(repositoryUrl, gerritSettings.getHost())) {
                     return Optional.of(remote);


### PR DESCRIPTION
Hi
Sometimes when using Gerrit in a larger organisation you can choose to have gerrit mirrors spread over the world. This means that developers will have this kind of git configuration
`[remote "origin"]
        fetch = +refs/heads/*:refs/remotes/origin/*
	url = ssh://user@gerritmirror.country.bigcompany.com:29418/project.git
	pushurl = ssh://user@gerrit.bigcompany.com:29418/project.git`
That means the gerrit plugin will fail when matching the hostname from the plugin configuration. If the hostname is matched also to the pushurl the fetching of changes will work also for this use case.
My colleagues and I used the gerrit plugin alot but the enforced "fetch from mirror only"-policy in our company made it impossible. We now use a build with this commit and we can review code again.
Thanks
almegren