### PR TITLE
change add comment shortcut to cmd+enter on macOS

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/CommentBalloonBuilder.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/CommentBalloonBuilder.java
@@ -17,6 +17,8 @@
 package com.urswolfer.intellij.plugin.gerrit.ui.diff;
 
 import com.google.inject.Inject;
+import com.intellij.openapi.actionSystem.CommonShortcuts;
+import com.intellij.openapi.keymap.KeymapUtil;
 import com.intellij.openapi.ui.popup.ComponentPopupBuilder;
 import com.intellij.openapi.ui.popup.JBPopup;
 import com.intellij.openapi.ui.popup.JBPopupFactory;
@@ -29,6 +31,9 @@ import org.jetbrains.annotations.NotNull;
  * https://github.com/ktisha/Crucible4IDEA
  */
 public class CommentBalloonBuilder {
+    private static final String POPUP_TEXT =
+        String.format("Hit %s to create a comment. It will be published once you post your review.",
+            KeymapUtil.getShortcutsText(CommonShortcuts.CTRL_ENTER.getShortcuts()));
 
     @Inject
     private JBPopupFactory jbPopupFactory;
@@ -36,7 +41,7 @@ public class CommentBalloonBuilder {
     public JBPopup getNewCommentBalloon(final CommentForm balloonContent, @NotNull final String title) {
         final ComponentPopupBuilder builder = jbPopupFactory.
                 createComponentPopupBuilder(balloonContent, balloonContent);
-        builder.setAdText("Hit Ctrl+Enter to create comment. It will be published once you post your review.");
+        builder.setAdText(POPUP_TEXT);
         builder.setTitle(title);
         builder.setResizable(true);
         builder.setMovable(true);

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/CommentForm.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/CommentForm.java
@@ -19,8 +19,10 @@ package com.urswolfer.intellij.plugin.gerrit.ui.diff;
 import com.google.gerrit.extensions.api.changes.DraftInput;
 import com.google.gerrit.extensions.client.Comment;
 import com.google.gerrit.extensions.client.Side;
+import com.intellij.openapi.actionSystem.CommonShortcuts;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.SelectionModel;
+import com.intellij.openapi.keymap.KeymapUtil;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.popup.JBPopup;
 import com.intellij.openapi.wm.IdeFocusManager;
@@ -76,7 +78,7 @@ public class CommentForm extends JPanel {
         reviewTextField.setPreferredSize(new Dimension(BALLOON_WIDTH, BALLOON_HEIGHT));
 
         reviewTextField.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).
-                put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, InputEvent.CTRL_DOWN_MASK), "postComment");
+                put(KeymapUtil.getKeyStroke(CommonShortcuts.CTRL_ENTER), "postComment");
         reviewTextField.getActionMap().put("postComment", new AbstractAction() {
             @Override
             public void actionPerformed(ActionEvent e) {


### PR DESCRIPTION
I've changed "add comment" shortcut on macOS from ctrl+enter to cmd+enter. Beware! It may confuse old users who are used to ctrl+enter here, but I believe it still should be changed because cmd+enter is more familiar to macOS users in such cases and it is more consistent with IntelliJ IDEA in general and with this plugin in particular.