### PR TITLE
Allow specifying the Clone Base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Installation
   - Download the [release](https://github.com/uwolfer/gerrit-intellij-plugin/releases)
   matching your IntelliJ version and install it manually using
   <kbd>Preferences</kbd> > <kbd>Plugins</kbd> > <kbd>Install plugin from disk...</kbd>
-  
+
 Restart your IDE.
 
 ###### Pre-Releases
@@ -64,7 +64,8 @@ Troubleshooting
 By default, you will only see changes to Git repositories that are configured in the current project of your IntelliJ IDE.
 * Make sure that Git repositories are configured in the 'Version Control' settings.
 * Make sure that the Git repository remote url (at least one of them) is on the same host as configured in Gerrit plugin settings. Or:
-* Add a remote whose name equals the Gerrit project name with Gerrit as remote url.
+* Set the 'Clone Base URL' if it differs from the Gerrit web url. Or:
+* Add a remote whose name equals the Gerrit project name with Gerrit web url as remote url.
 
 ### Error-message when clicking a change: "VcsException: fatal: bad object"
 In Gerrit 2.8, fetch information was pulled out of default functionality into a plugin.

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
@@ -61,6 +61,7 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
     private static final String SHOW_CHANGE_ID_COLUMN = "ShowChangeIdColumn";
     private static final String SHOW_TOPIC_COLUMN = "ShowTopicColumn";
     private static final String SHOW_PROJECT_COLUMN = "ShowProjectColumn";
+    private static final String CLONE_BASE_URL = "CloneBaseUrl";
     private static final String GERRIT_SETTINGS_PASSWORD_KEY = "GERRIT_SETTINGS_PASSWORD_KEY";
 
     private String login = "";
@@ -74,6 +75,7 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
     private boolean showChangeIdColumn = false;
     private boolean showTopicColumn = false;
     private ShowProjectColumn showProjectColumn = ShowProjectColumn.AUTO;
+    private String cloneBaseUrl = "";
 
     private Optional<String> preloadedPassword;
 
@@ -92,6 +94,7 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
         element.setAttribute(SHOW_CHANGE_ID_COLUMN, Boolean.toString(getShowChangeIdColumn()));
         element.setAttribute(SHOW_TOPIC_COLUMN, Boolean.toString(getShowTopicColumn()));
         element.setAttribute(SHOW_PROJECT_COLUMN, getShowProjectColumn().name());
+        element.setAttribute(CLONE_BASE_URL, (getCloneBaseUrl() != null ? getCloneBaseUrl() : ""));
         return element;
     }
 
@@ -110,6 +113,7 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
             setShowChangeIdColumn(getBooleanValue(element, SHOW_CHANGE_ID_COLUMN));
             setShowTopicColumn(getBooleanValue(element, SHOW_TOPIC_COLUMN));
             setShowProjectColumn(getShowProjectColumnValue(element, SHOW_PROJECT_COLUMN));
+            setCloneBaseUrl(element.getAttributeValue(CLONE_BASE_URL));
         } catch (Exception e) {
             log.error("Error happened while loading gerrit settings: " + e);
         }
@@ -290,6 +294,15 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
     public void setShowTopicColumn(boolean showTopicColumn) {
         this.showTopicColumn = showTopicColumn;
     }
+
+    public void setCloneBaseUrl(String cloneBaseUrl) {
+        this.cloneBaseUrl = cloneBaseUrl;
+    }
+
+    public String getCloneBaseUrl() {
+        return cloneBaseUrl;
+    }
+
 
     public void setLog(Logger log) {
         this.log = log;

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/extension/GerritCheckoutProvider.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/extension/GerritCheckoutProvider.java
@@ -18,6 +18,7 @@
 package com.urswolfer.intellij.plugin.gerrit.extension;
 
 import com.google.common.base.Function;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Ordering;
@@ -138,12 +139,15 @@ public class GerritCheckoutProvider implements CheckoutProvider {
     }
 
     /**
-     * Try to determinate Git clone url by fetching a random change and processing its fetch url. If it fails, falling
-     * back to Gerrit host url config.
+     * If set, return the clone base url from the preferences. Otherwise, try to determine the Git clone url by
+     * fetching a random change and processing its fetch url. If it fails, fall back to Gerrit host url config.
      *
      * This can be cleaned up once https://code.google.com/p/gerrit/issues/detail?id=2208 is implemented.
      */
     private String getCloneBaseUrl() {
+        if (!Strings.isNullOrEmpty(gerritSettings.getCloneBaseUrl())) {
+            return gerritSettings.getCloneBaseUrl();
+        }
         String url = gerritSettings.getHost();
         try {
             List<ChangeInfo> changeInfos = gerritApi.changes().query()

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/GerritUtil.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/GerritUtil.java
@@ -390,7 +390,8 @@ public class GerritUtil {
         for (GitRemote remote : remotes) {
             for (String remoteUrl : remote.getUrls()) {
                 remoteUrl = UrlUtils.stripGitExtension(remoteUrl);
-                String projectName = getProjectName(gerritSettings.getHost(), remoteUrl);
+                String projectName = getProjectName(gerritSettings.getHost(), gerritSettings.getCloneBaseUrl(),
+                    remoteUrl);
                 if (!Strings.isNullOrEmpty(projectName) && remoteUrl.endsWith(projectName)) {
                     projectNames.add(projectName);
                 }
@@ -399,12 +400,13 @@ public class GerritUtil {
         return projectNames;
     }
 
-    private String getProjectName(String repositoryUrl, String url) {
-        if (!repositoryUrl.endsWith("/")) {
-            repositoryUrl = repositoryUrl + "/";
+    private String getProjectName(String gerritUrl, String gerritCloneBaseUrl,  String url) {
+        String baseUrl = Strings.isNullOrEmpty(gerritCloneBaseUrl) ? gerritUrl : gerritCloneBaseUrl;
+        if (!baseUrl.endsWith("/")) {
+            baseUrl = baseUrl + "/";
         }
 
-        String basePath = UrlUtils.createUriFromGitConfigString(repositoryUrl).getPath();
+        String basePath = UrlUtils.createUriFromGitConfigString(baseUrl).getPath();
         String path = UrlUtils.createUriFromGitConfigString(url).getPath();
 
         if (path.length() >= basePath.length() && path.startsWith(basePath)) {
@@ -416,9 +418,9 @@ public class GerritUtil {
         if (path.endsWith("/")) {
             path = path.substring(0, path.length() - 1);
         }
-        // gerrit project names usually dont start with a slash
+        // gerrit project names usually don't start with a slash
         if (path.startsWith("/")) {
-            path = path.substring(1, path.length());
+            path = path.substring(1);
         }
 
         return path;

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritSettingsConfigurable.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritSettingsConfigurable.java
@@ -77,7 +77,8 @@ public class GerritSettingsConfigurable implements SearchableConfigurable, VcsCo
                 !Comparing.equal(gerritSettings.getShowChangeNumberColumn(), settingsPane.getShowChangeNumberColumn()) ||
                 !Comparing.equal(gerritSettings.getShowChangeIdColumn(), settingsPane.getShowChangeIdColumn()) ||
                 !Comparing.equal(gerritSettings.getShowTopicColumn(), settingsPane.getShowTopicColumn()) ||
-                !Comparing.equal(gerritSettings.getShowProjectColumn(), settingsPane.getShowProjectColumn()));
+                !Comparing.equal(gerritSettings.getShowProjectColumn(), settingsPane.getShowProjectColumn()) ||
+                !Comparing.equal(gerritSettings.getCloneBaseUrl(), settingsPane.getCloneBaseUrl()));
     }
 
     private boolean isPasswordModified() {
@@ -101,6 +102,7 @@ public class GerritSettingsConfigurable implements SearchableConfigurable, VcsCo
             gerritSettings.setShowChangeIdColumn(settingsPane.getShowChangeIdColumn());
             gerritSettings.setShowTopicColumn(settingsPane.getShowTopicColumn());
             gerritSettings.setShowProjectColumn(settingsPane.getShowProjectColumn());
+            gerritSettings.setCloneBaseUrl(settingsPane.getCloneBaseUrl());
 
             gerritUpdatesNotificationComponent.handleConfigurationChange();
         }
@@ -122,6 +124,7 @@ public class GerritSettingsConfigurable implements SearchableConfigurable, VcsCo
             settingsPane.setShowChangeIdColumn(gerritSettings.getShowChangeIdColumn());
             settingsPane.setShowTopicColumn(gerritSettings.getShowTopicColumn());
             settingsPane.setShowProjectColumn(gerritSettings.getShowProjectColumn());
+            settingsPane.setCloneBaseUrl(gerritSettings.getCloneBaseUrl());
         }
     }
 

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/SettingsPanel.form
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/SettingsPanel.form
@@ -3,7 +3,7 @@
   <grid id="9dc44" binding="pane" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="563" height="448"/>
+      <xy x="20" y="20" width="563" height="511"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -100,7 +100,7 @@
               </component>
             </children>
           </grid>
-          <grid id="d87b1" binding="settingsPane" layout-manager="GridLayoutManager" row-count="8" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="d87b1" binding="settingsPane" layout-manager="GridLayoutManager" row-count="10" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
               <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
@@ -223,6 +223,43 @@
                   </component>
                 </children>
               </grid>
+              <grid id="46307" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                <margin top="0" left="0" bottom="0" right="0"/>
+                <constraints>
+                  <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties/>
+                <border type="none"/>
+                <children>
+                  <component id="65f1d" class="javax.swing.JLabel">
+                    <constraints>
+                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value="Clone Base URL"/>
+                      <toolTipText value=""/>
+                    </properties>
+                  </component>
+                  <component id="7a077" class="javax.swing.JTextField" binding="cloneBaseUrlTextField">
+                    <constraints>
+                      <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                        <preferred-size width="150" height="-1"/>
+                      </grid>
+                    </constraints>
+                    <properties>
+                      <toolTipText value=""/>
+                    </properties>
+                  </component>
+                </children>
+              </grid>
+              <component id="80a49" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Set a clone base URL if it differs from the Gerrit web URL."/>
+                </properties>
+              </component>
             </children>
           </grid>
           <vspacer id="69494">

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/SettingsPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/SettingsPanel.java
@@ -62,6 +62,7 @@ public class SettingsPanel {
     private JCheckBox showChangeIdColumnCheckBox;
     private JCheckBox showTopicColumnCheckBox;
     private JComboBox showProjectColumnComboBox;
+    private JTextField cloneBaseUrlTextField;
 
     private boolean passwordModified;
 
@@ -133,6 +134,13 @@ public class SettingsPanel {
         });
 
         showProjectColumnComboBox.setModel(new EnumComboBoxModel(ShowProjectColumn.class));
+
+        cloneBaseUrlTextField.addFocusListener(new FocusAdapter() {
+            @Override
+            public void focusLost(FocusEvent e) {
+                fixUrl(cloneBaseUrlTextField);
+            }
+        });
     }
 
     public static void fixUrl(JTextField textField) {
@@ -259,5 +267,14 @@ public class SettingsPanel {
     public void resetPasswordModification() {
         passwordModified = false;
     }
+
+    public void setCloneBaseUrl(final String cloneBaseUrl) {
+        cloneBaseUrlTextField.setText(cloneBaseUrl);
+    }
+
+    public String getCloneBaseUrl() {
+        return cloneBaseUrlTextField.getText().trim();
+    }
+
 }
 


### PR DESCRIPTION
This fixes the detection of the project name for non-standard setups and allows
to specify the preferred URL in the 'Clone Repository' dialog

Fix: #323 #322 #194 #12