### PR TITLE
Branch name acquiring from .gitreview file with fallback to local branch

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
@@ -91,25 +91,11 @@ public class GerritPushExtensionPanel extends JPanel {
         initialized = true;
 
         if (gerritPushTargetPanels.size() == 1) {
-            String branchName;
+            String branchName = gerritPushTargetPanels.values().iterator().next();
 
-            try {
-                String gitReviewFilePath = StringUtils.join(
-                    new String[]{ProjectManager.getInstance().getOpenProjects()[0].getBasePath(), GITREVIEW_FILENAME}, File.separator);
+            String gitReviewBranchName = getGitReviewBranchName();
 
-                Properties properties = new Properties();
-                properties.load(new FileInputStream(gitReviewFilePath));
-
-                branchName = properties.getProperty("defaultbranch");
-            } catch (IOException e) {
-                branchName = gerritPushTargetPanels.values().iterator().next();
-            }
-
-            if (branchName == null) {
-                branchName = gerritPushTargetPanels.values().iterator().next();
-            }
-
-            branchTextField.setText(branchName);
+            branchTextField.setText(gitReviewBranchName == null ? branchName : gitReviewBranchName);
         }
 
         // force a deferred update (changes are monitored only after full construction of dialog)
@@ -118,6 +104,29 @@ public class GerritPushExtensionPanel extends JPanel {
                 initDestinationBranch();
             }
         });
+    }
+
+    private String getGitReviewBranchName() {
+        String branchName = null;
+
+        String gitReviewFilePath = StringUtils.join(
+            new String[]{ProjectManager.getInstance().getOpenProjects()[0].getBasePath(), GITREVIEW_FILENAME}, File.separator);
+
+        File gitReviewFile = new File(gitReviewFilePath);
+        if (gitReviewFile.exists() && gitReviewFile.isFile()) {
+            try {
+                FileInputStream fileInputStream = new FileInputStream(gitReviewFilePath);
+
+                Properties properties = new Properties();
+                properties.load(fileInputStream);
+                branchName = properties.getProperty("defaultbranch");
+
+                fileInputStream.close();
+            } catch (IOException e) {
+            }
+        }
+
+        return branchName;
     }
 
     private void createLayout() {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
@@ -21,9 +21,11 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.intellij.openapi.project.ProjectManager;
 import com.intellij.uiDesigner.core.GridConstraints;
 import com.intellij.uiDesigner.core.GridLayoutManager;
 import com.intellij.util.ui.UIUtil;
+import org.apache.commons.lang.StringUtils;
 
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
@@ -31,8 +33,12 @@ import javax.swing.event.DocumentListener;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * @author Urs Wolfer
@@ -40,6 +46,7 @@ import java.util.Map;
 public class GerritPushExtensionPanel extends JPanel {
 
     private static final Splitter COMMA_SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
+    private static final String GITREVIEW_FILENAME = ".gitreview";
 
     private final boolean pushToGerritByDefault;
 
@@ -84,7 +91,25 @@ public class GerritPushExtensionPanel extends JPanel {
         initialized = true;
 
         if (gerritPushTargetPanels.size() == 1) {
-            branchTextField.setText(gerritPushTargetPanels.values().iterator().next());
+            String branchName;
+
+            try {
+                String gitReviewFilePath = StringUtils.join(
+                    new String[]{ProjectManager.getInstance().getOpenProjects()[0].getBasePath(), GITREVIEW_FILENAME}, File.separator);
+
+                Properties properties = new Properties();
+                properties.load(new FileInputStream(gitReviewFilePath));
+
+                branchName = properties.getProperty("defaultbranch");
+            } catch (IOException e) {
+                branchName = gerritPushTargetPanels.values().iterator().next();
+            }
+
+            if (branchName == null) {
+                branchName = gerritPushTargetPanels.values().iterator().next();
+            }
+
+            branchTextField.setText(branchName);
         }
 
         // force a deferred update (changes are monitored only after full construction of dialog)


### PR DESCRIPTION
During "Push to gerrit" stage branch name is taken from .gitreview file. If file or property does not exist it will fallback to local branch name as it always was before. Such approach could be handful while using feature-branch workflow.