### PR TITLE
Fix for null DataContext when invoking push dialog from hotkey

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
@@ -113,7 +113,7 @@ public class GerritPushExtensionPanel extends JPanel {
     private Optional<String> getGitReviewBranchName() {
         Optional<String> branchName = Optional.absent();
 
-        DataContext dataContext = DataManager.getInstance().getDataContextFromFocus().getResult();
+        DataContext dataContext = DataManager.getInstance().getDataContext(this);
         Optional<Project> openedProject = dataContext != null ?
             Optional.fromNullable(CommonDataKeys.PROJECT.getData(dataContext)) : Optional.<Project>absent();
 
@@ -130,6 +130,10 @@ public class GerritPushExtensionPanel extends JPanel {
                     Properties properties = new Properties();
                     properties.load(fileInputStream);
                     branchName = Optional.fromNullable(properties.getProperty("defaultbranch"));
+
+                    if (branchName.isPresent() && branchName.get().isEmpty()) {
+                        return Optional.absent();
+                    }
                 } catch (IOException e) {
                     //no need to handle as branch name is already absent and ready to be returned
                 } finally {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
@@ -129,11 +129,7 @@ public class GerritPushExtensionPanel extends JPanel {
 
                     Properties properties = new Properties();
                     properties.load(fileInputStream);
-                    branchName = Optional.fromNullable(properties.getProperty("defaultbranch"));
-
-                    if (branchName.isPresent() && Strings.isNullOrEmpty(branchName.get())) {
-                        return Optional.absent();
-                    }
+                    branchName = Optional.fromNullable(Strings.emptyToNull(properties.getProperty("defaultbranch")));
                 } catch (IOException e) {
                     //no need to handle as branch name is already absent and ready to be returned
                 } finally {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
@@ -131,7 +131,7 @@ public class GerritPushExtensionPanel extends JPanel {
                     properties.load(fileInputStream);
                     branchName = Optional.fromNullable(properties.getProperty("defaultbranch"));
 
-                    if (branchName.isPresent() && branchName.get().isEmpty()) {
+                    if (branchName.isPresent() && Strings.isNullOrEmpty(branchName.get())) {
                         return Optional.absent();
                     }
                 } catch (IOException e) {


### PR DESCRIPTION
Fixed null DataContext when invoking push dialog from hotkey. DataContext could be normally acquired from .getDataContext(this) since the invocation is happening within Runnable that executes after the push dialog is constructed.

Fixed empty branch name if .gitreview contains following text:
defaultbranch=

related to issue #329 