### PR TITLE
add function getCloneBaseUrlOrHost in GerritSettings

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
@@ -311,8 +311,11 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
         return cloneBaseUrl;
     }
 
-
     public void setLog(Logger log) {
         this.log = log;
+    }
+
+    public String getCloneBaseUrlOrHost() {
+        return Strings.isNullOrEmpty(cloneBaseUrl) ? host : cloneBaseUrl;
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/git/GerritGitUtil.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/git/GerritGitUtil.java
@@ -137,7 +137,7 @@ public class GerritGitUtil {
             repositoryUrls.addAll(remote.getPushUrls());
             for (String repositoryUrl : repositoryUrls) {
                 if (UrlUtils.urlHasSameHost(repositoryUrl, url)
-                    || UrlUtils.urlHasSameHost(repositoryUrl, gerritSettings.getHost())) {
+                    || UrlUtils.urlHasSameHost(repositoryUrl, gerritSettings.getCloneBaseUrlOrHost())) {
                     return Optional.of(remote);
                 }
             }


### PR DESCRIPTION
We need to use the clone base URL instead of HOST for fetch a change from the remote repository.