### PR TITLE
Test case refactoring to remove test smell

### DIFF
--- a/src/test/java/com/urswolfer/intellij/plugin/gerrit/util/UrlUtilsTest.java
+++ b/src/test/java/com/urswolfer/intellij/plugin/gerrit/util/UrlUtilsTest.java
@@ -27,17 +27,23 @@ import java.net.URI;
 public class UrlUtilsTest {
 
     @Test
-    public void testUrlHasSameHost() throws Exception {
+    public void testUrlHasSameHostTrue() throws Exception {
         Assert.assertTrue(UrlUtils.urlHasSameHost("https://gerrit.example.com/test.git", "https://gerrit.example.com/"));
+    }
 
+    @Test
+    public void testUrlHasSameHostFalse() throws Exception {
         Assert.assertFalse(UrlUtils.urlHasSameHost("https://git.example.com/test.git", "https://gerrit.example.com/"));
     }
 
     @Test
-    public void testCreateUriFromGitConfigString() throws Exception {
+    public void testCreateUriFromGitConfigStringWithProtocol() throws Exception {
         URI uriFromGitConfigString = UrlUtils.createUriFromGitConfigString("https://git.example.com/");
         Assert.assertEquals(uriFromGitConfigString.toString(), "https://git.example.com/");
+    }
 
+    @Test
+    public void testCreateUriFromGitConfigStringWithoutProtocol() throws Exception {
         URI uriFromGitConfigStringWithoutProtocol = UrlUtils.createUriFromGitConfigString("git.example.com/");
         Assert.assertEquals(uriFromGitConfigStringWithoutProtocol.toString(), "git://git.example.com/");
     }


### PR DESCRIPTION
This is a test refactoring. 

Problem:
The assertion roulette test smell occurs when a test method has multiple non-documented assertions. Various assertion statements in a test method without a descriptive message impacts readability/understandability/maintainability as it is not possible to understand the reason for the failure of the test.

Solution:
The refactoring consisted of splitting multiple assertion methods into single assertion ones, indicating the test specificity in its name.

No assertion from the original test was changed.