### PR TITLE
Revert "Bump gerrit-rest-java-client from 0.9.3 to 0.9.4"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation ('com.google.inject.extensions:guice-multibindings:4.2.3') {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    implementation ('com.urswolfer.gerrit.client.rest:gerrit-rest-java-client:0.9.4') {
+    implementation ('com.urswolfer.gerrit.client.rest:gerrit-rest-java-client:0.9.3') {
         exclude group: 'com.google.code.gson', module: 'gson'
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'commons-logging', module: 'commons-logging'


### PR DESCRIPTION
Reverts uwolfer/gerrit-intellij-plugin#441

This breaks with httpclient version bundled with IntelliJ IC-2016.2.5.