### PR TITLE
Revert "Bump guice from 4.1 to 5.1.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
 }
 
 dependencies {
-    implementation ('com.google.inject:guice:5.1.0') {
+    implementation ('com.google.inject:guice:4.1') {
         exclude group: 'com.google.guava', module: 'guava'
     }
     implementation ('com.google.inject.extensions:guice-multibindings:4.2.3') {


### PR DESCRIPTION
Reverts uwolfer/gerrit-intellij-plugin#435

This breaks with guava version bundled with IntelliJ IC-2016.2.5.