### PR TITLE
Revert "Bump guice-multibindings from 4.1.0 to 4.2.3"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation ('com.google.inject:guice:5.1.0') {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    implementation ('com.google.inject.extensions:guice-multibindings:4.2.3') {
+    implementation ('com.google.inject.extensions:guice-multibindings:4.1.0') {
         exclude group: 'com.google.guava', module: 'guava'
     }
     implementation ('com.urswolfer.gerrit.client.rest:gerrit-rest-java-client:0.9.4') {


### PR DESCRIPTION
Reverts uwolfer/gerrit-intellij-plugin#438

This breaks with guava version bundled with IntelliJ IC-2016.2.5.