### PR TITLE
Add force branch name settings

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
@@ -55,6 +55,7 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
     private static final String SHOW_TOPIC_COLUMN = "ShowTopicColumn";
     private static final String SHOW_PROJECT_COLUMN = "ShowProjectColumn";
     private static final String CLONE_BASE_URL = "CloneBaseUrl";
+    private static final String FORCE_DEFAULT_BRANCH = "ForceDefaultBranch";
     private static final String GERRIT_SETTINGS_PASSWORD_KEY = "GERRIT_SETTINGS_PASSWORD_KEY";
     private static final CredentialAttributes CREDENTIAL_ATTRIBUTES = new CredentialAttributes(GerritSettings.class.getName(), GERRIT_SETTINGS_PASSWORD_KEY);
 
@@ -70,6 +71,7 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
     private boolean showTopicColumn = false;
     private ShowProjectColumn showProjectColumn = ShowProjectColumn.AUTO;
     private String cloneBaseUrl = "";
+    private boolean forceDefaultBranch = false;
 
     private Optional<String> preloadedPassword;
 
@@ -89,6 +91,7 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
         element.setAttribute(SHOW_TOPIC_COLUMN, Boolean.toString(getShowTopicColumn()));
         element.setAttribute(SHOW_PROJECT_COLUMN, getShowProjectColumn().name());
         element.setAttribute(CLONE_BASE_URL, (getCloneBaseUrl() != null ? getCloneBaseUrl() : ""));
+        element.setAttribute(FORCE_DEFAULT_BRANCH, Boolean.toString(getForceDefaultBranch()));
         return element;
     }
 
@@ -108,6 +111,7 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
             setShowTopicColumn(getBooleanValue(element, SHOW_TOPIC_COLUMN));
             setShowProjectColumn(getShowProjectColumnValue(element, SHOW_PROJECT_COLUMN));
             setCloneBaseUrl(element.getAttributeValue(CLONE_BASE_URL));
+            setForceDefaultBranch(getBooleanValue(element, FORCE_DEFAULT_BRANCH));
         } catch (Exception e) {
             log.error("Error happened while loading gerrit settings: " + e);
         }
@@ -274,6 +278,14 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
 
     public String getCloneBaseUrl() {
         return cloneBaseUrl;
+    }
+
+    public void setForceDefaultBranch(boolean forceDefaultBranch) {
+        this.forceDefaultBranch = forceDefaultBranch;
+    }
+
+    public boolean getForceDefaultBranch() {
+         return this.forceDefaultBranch;
     }
 
     public void setLog(Logger log) {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtension.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtension.java
@@ -66,12 +66,13 @@ public class GerritPushExtension implements NamedComponent {
     private void modifyGitBranchPanel(ClassPool classPool, ClassLoader classLoader) {
         try {
             boolean pushToGerrit = gerritSettings.getPushToGerrit();
+            boolean forceDefaultBranch = gerritSettings.getForceDefaultBranch();
 
             CtClass gitPushSupportClass = classPool.get("git4idea.push.GitPushSupport");
             CtClass gerritPushOptionsPanelClass = classPool.get("com.urswolfer.intellij.plugin.gerrit.push.GerritPushOptionsPanel");
 
             gitPushSupportClass.addField(new CtField(gerritPushOptionsPanelClass, "gerritPushOptionsPanel", gitPushSupportClass),
-                    "new com.urswolfer.intellij.plugin.gerrit.push.GerritPushOptionsPanel(" + pushToGerrit + ");");
+                    "new com.urswolfer.intellij.plugin.gerrit.push.GerritPushOptionsPanel(" + pushToGerrit + "," + forceDefaultBranch + ");");
 
             CtMethod createOptionsPanelMethod = gitPushSupportClass.getDeclaredMethod("createOptionsPanel");
             createOptionsPanelMethod.setBody(

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtension.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtension.java
@@ -113,6 +113,7 @@ public class GerritPushExtension implements NamedComponent {
         loadClass(classPool, targetClassLoader, "com.urswolfer.intellij.plugin.gerrit.push.GerritPushTargetPanel$1");
         loadClass(classPool, targetClassLoader, "com.urswolfer.intellij.plugin.gerrit.push.GerritPushExtensionPanel");
         loadClass(classPool, targetClassLoader, "com.urswolfer.intellij.plugin.gerrit.push.GerritPushExtensionPanel$1");
+        loadClass(classPool, targetClassLoader, "com.urswolfer.intellij.plugin.gerrit.push.GerritPushExtensionPanel$1$1");
         loadClass(classPool, targetClassLoader, "com.urswolfer.intellij.plugin.gerrit.push.GerritPushExtensionPanel$ChangeActionListener");
         loadClass(classPool, targetClassLoader, "com.urswolfer.intellij.plugin.gerrit.push.GerritPushExtensionPanel$ChangeTextActionListener");
         loadClass(classPool, targetClassLoader, "com.urswolfer.intellij.plugin.gerrit.push.GerritPushExtensionPanel$SettingsStateActionListener");

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
@@ -53,6 +53,7 @@ public class GerritPushExtensionPanel extends JPanel {
     private static final String GITREVIEW_FILENAME = ".gitreview";
 
     private final boolean pushToGerritByDefault;
+    private final boolean forceDefaultBranch;
 
     private JPanel indentedSettingPanel;
 
@@ -70,11 +71,12 @@ public class GerritPushExtensionPanel extends JPanel {
     private JTextField reviewersTextField;
     private JTextField ccTextField;
     private JTextField patchsetDescriptionTextField;
-    private Map<GerritPushTargetPanel, String> gerritPushTargetPanels = Maps.newHashMap();
+    private final Map<GerritPushTargetPanel, String> gerritPushTargetPanels = Maps.newHashMap();
     private boolean initialized = false;
 
-    public GerritPushExtensionPanel(boolean pushToGerritByDefault) {
+    public GerritPushExtensionPanel(boolean pushToGerritByDefault, boolean forceDefaultBranch) {
         this.pushToGerritByDefault = pushToGerritByDefault;
+        this.forceDefaultBranch = forceDefaultBranch;
         createLayout();
 
         pushToGerritCheckBox.setSelected(pushToGerritByDefault);
@@ -104,7 +106,12 @@ public class GerritPushExtensionPanel extends JPanel {
         // force a deferred update (changes are monitored only after full construction of dialog)
         SwingUtilities.invokeLater(new Runnable() {
             public void run() {
-                if (gerritPushTargetPanels.size() == 1) {
+                if (forceDefaultBranch) {
+                    Optional<String> gitReviewBranchName = getGitReviewBranchName();
+                    if(gitReviewBranchName.isPresent()) {
+                        branchTextField.setText(gitReviewBranchName.get());
+                    }
+                } else if (gerritPushTargetPanels.size() == 1) {
                     String branchName = gerritPushTargetPanels.values().iterator().next();
                     Optional<String> gitReviewBranchName = getGitReviewBranchName();
                     branchTextField.setText(gitReviewBranchName.or(branchName));
@@ -118,8 +125,7 @@ public class GerritPushExtensionPanel extends JPanel {
         Optional<String> branchName = Optional.absent();
 
         DataContext dataContext = DataManager.getInstance().getDataContext(this);
-        Optional<Project> openedProject = dataContext != null ?
-            Optional.fromNullable(CommonDataKeys.PROJECT.getData(dataContext)) : Optional.<Project>absent();
+        Optional<Project> openedProject = Optional.fromNullable(CommonDataKeys.PROJECT.getData(dataContext));
 
         if (openedProject.isPresent()) {
             String gitReviewFilePath = Joiner.on(File.separator).join(
@@ -127,24 +133,15 @@ public class GerritPushExtensionPanel extends JPanel {
 
             File gitReviewFile = new File(gitReviewFilePath);
             if (gitReviewFile.exists() && gitReviewFile.isFile()) {
-                FileInputStream fileInputStream = null;
-                try {
-                    fileInputStream = new FileInputStream(gitReviewFilePath);
+                try (FileInputStream fileInputStream = new FileInputStream(gitReviewFilePath)) {
 
                     Properties properties = new Properties();
                     properties.load(fileInputStream);
                     branchName = Optional.fromNullable(Strings.emptyToNull(properties.getProperty("defaultbranch")));
                 } catch (IOException e) {
                     //no need to handle as branch name is already absent and ready to be returned
-                } finally {
-                    if (fileInputStream != null) {
-                        try {
-                            fileInputStream.close();
-                        } catch (IOException e) {
-                            //no need to handle as branch name is already absent and ready to be returned
-                        }
-                    }
                 }
+                //no need to handle as branch name is already absent and ready to be returned
             }
         }
 

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
@@ -30,6 +30,11 @@ import com.intellij.uiDesigner.core.GridConstraints;
 import com.intellij.uiDesigner.core.GridLayoutManager;
 import com.intellij.util.ui.UIUtil;
 import com.urswolfer.intellij.plugin.gerrit.util.UrlUtils;
+import git4idea.commands.Git;
+import git4idea.commands.GitCommand;
+import git4idea.commands.GitLineHandler;
+import git4idea.repo.GitRepository;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
@@ -43,6 +48,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
 
 /**
  * @author Urs Wolfer
@@ -51,6 +58,7 @@ public class GerritPushExtensionPanel extends JPanel {
 
     private static final Splitter COMMA_SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
     private static final String GITREVIEW_FILENAME = ".gitreview";
+    private static final Pattern REMOTE_HEAD_NAME = Pattern.compile(".*HEAD.*: (.+)");
 
     private final boolean pushToGerritByDefault;
     private final boolean forceDefaultBranch;
@@ -72,6 +80,7 @@ public class GerritPushExtensionPanel extends JPanel {
     private JTextField ccTextField;
     private JTextField patchsetDescriptionTextField;
     private final Map<GerritPushTargetPanel, String> gerritPushTargetPanels = Maps.newHashMap();
+    private GitRepository repository;
     private boolean initialized = false;
 
     public GerritPushExtensionPanel(boolean pushToGerritByDefault, boolean forceDefaultBranch) {
@@ -86,11 +95,12 @@ public class GerritPushExtensionPanel extends JPanel {
         addChangeListener();
     }
 
-    public void registerGerritPushTargetPanel(GerritPushTargetPanel gerritPushTargetPanel, String branch) {
+    public void registerGerritPushTargetPanel(GerritPushTargetPanel gerritPushTargetPanel, String branch, @NotNull GitRepository gitRepository) {
         if (initialized) { // a new dialog gets initialized; start again
             initialized = false;
             gerritPushTargetPanels.clear();
         }
+        repository = gitRepository;
 
         if (branch != null) {
             branch = branch.replaceAll("^refs/(for|drafts)/", "");
@@ -103,22 +113,39 @@ public class GerritPushExtensionPanel extends JPanel {
     public void initialized() {
         initialized = true;
 
-        // force a deferred update (changes are monitored only after full construction of dialog)
-        SwingUtilities.invokeLater(new Runnable() {
-            public void run() {
+        // force update in background because the force default branch does some IO
+        SwingWorker<Optional<String>, Void> worker = new SwingWorker<>() {
+            @Override
+            protected Optional<String> doInBackground() {
                 if (forceDefaultBranch) {
-                    Optional<String> gitReviewBranchName = getGitReviewBranchName();
-                    if(gitReviewBranchName.isPresent()) {
-                        branchTextField.setText(gitReviewBranchName.get());
+                    Optional<String> branchName = getGitReviewBranchName();
+                    if (branchName.isPresent()) {
+                        return branchName;
                     }
+                    return findDefaultRemoteBranch();
                 } else if (gerritPushTargetPanels.size() == 1) {
-                    String branchName = gerritPushTargetPanels.values().iterator().next();
-                    Optional<String> gitReviewBranchName = getGitReviewBranchName();
-                    branchTextField.setText(gitReviewBranchName.or(branchName));
+                    Optional<String> branchName = Optional.of(gerritPushTargetPanels.values().iterator().next());
+                    return getGitReviewBranchName().or(branchName);
                 }
-                initDestinationBranch();
+                return Optional.absent();
             }
-        });
+
+            @Override
+            protected void done() {
+                try {
+                    Optional<String> branchName = get();
+                    if (branchName.isPresent()) {
+                        branchTextField.setText(branchName.get());
+                    }
+                    initDestinationBranch();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                } catch (ExecutionException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+        worker.execute();
     }
 
     private Optional<String> getGitReviewBranchName() {
@@ -146,6 +173,30 @@ public class GerritPushExtensionPanel extends JPanel {
         }
 
         return branchName;
+    }
+
+    /**
+     * Use Git CLI to find default remote branch name.
+     * This command calls the remote URLs.
+     */
+    public Optional<String> findDefaultRemoteBranch() {
+        final Git git = Git.getInstance();
+
+        final GitLineHandler h = new GitLineHandler(repository.getProject(), repository.getRoot(), GitCommand.REMOTE);
+        h.addParameters("show", "origin");
+
+        List<String> output = git.runCommand(h).getOutput();
+
+        Optional<String> defaultBranch = Optional.absent();
+        for (String line : output) {
+            var matcher = REMOTE_HEAD_NAME.matcher(line);
+            if (matcher.find()) {
+                defaultBranch = Optional.of(matcher.group(1));
+                break;
+            }
+        }
+
+        return defaultBranch;
     }
 
     private void createLayout() {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
@@ -25,6 +25,8 @@ import com.google.common.collect.Maps;
 import com.intellij.ide.DataManager;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
+import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.uiDesigner.core.GridConstraints;
 import com.intellij.uiDesigner.core.GridLayoutManager;
@@ -113,39 +115,34 @@ public class GerritPushExtensionPanel extends JPanel {
     public void initialized() {
         initialized = true;
 
-        // force update in background because the force default branch does some IO
-        SwingWorker<Optional<String>, Void> worker = new SwingWorker<>() {
+        Task task = new Task.Backgroundable(repository.getProject(), "Get default branch name", false) {
             @Override
-            protected Optional<String> doInBackground() {
+            public void run(@NotNull ProgressIndicator progressIndicator) {
+                Optional<String> branchName = Optional.absent();
                 if (forceDefaultBranch) {
-                    Optional<String> branchName = getGitReviewBranchName();
-                    if (branchName.isPresent()) {
-                        return branchName;
+                    Optional<String> gitReviewBranchName = getGitReviewBranchName();
+                    if (gitReviewBranchName.isPresent()) {
+                        branchName = gitReviewBranchName;
+                    } else {
+                        branchName = findDefaultRemoteBranch();
                     }
-                    return findDefaultRemoteBranch();
                 } else if (gerritPushTargetPanels.size() == 1) {
-                    Optional<String> branchName = Optional.of(gerritPushTargetPanels.values().iterator().next());
-                    return getGitReviewBranchName().or(branchName);
+                    Optional<String> pushTargetBranchName = Optional.of(gerritPushTargetPanels.values().iterator().next());
+                    branchName = getGitReviewBranchName().or(pushTargetBranchName);
                 }
-                return Optional.absent();
-            }
 
-            @Override
-            protected void done() {
-                try {
-                    Optional<String> branchName = get();
-                    if (branchName.isPresent()) {
-                        branchTextField.setText(branchName.get());
+                Optional<String> finalBranchName = branchName;
+                SwingUtilities.invokeLater(new Runnable() {
+                    public void run() {
+                        if(finalBranchName.isPresent()) {
+                            branchTextField.setText(finalBranchName.get());
+                        }
+                        initDestinationBranch();
                     }
-                    initDestinationBranch();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                } catch (ExecutionException e) {
-                    throw new RuntimeException(e);
-                }
+                });
             }
         };
-        worker.execute();
+        task.queue();
     }
 
     private Optional<String> getGitReviewBranchName() {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
@@ -115,6 +115,7 @@ public class GerritPushExtensionPanel extends JPanel {
     public void initialized() {
         initialized = true;
 
+        // force a deferred update (changes are monitored only after full construction of dialog)
         Task task = new Task.Backgroundable(repository.getProject(), "Get default branch name", false) {
             @Override
             public void run(@NotNull ProgressIndicator progressIndicator) {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushOptionsPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushOptionsPanel.java
@@ -34,8 +34,8 @@ public class GerritPushOptionsPanel extends VcsPushOptionsPanel {
     private final GerritPushExtensionPanel gerritPushExtensionPanel;
     private GitPushOptionsPanel gitPushOptionsPanel;
 
-    public GerritPushOptionsPanel(boolean pushToGerrit) {
-        gerritPushExtensionPanel = new GerritPushExtensionPanel(pushToGerrit);
+    public GerritPushOptionsPanel(boolean pushToGerrit, boolean forceDefaultBranch) {
+        gerritPushExtensionPanel = new GerritPushExtensionPanel(pushToGerrit, forceDefaultBranch);
     }
 
     @SuppressWarnings("UnusedDeclaration") // javassist call

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushTargetPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushTargetPanel.java
@@ -43,7 +43,7 @@ public class GerritPushTargetPanel extends GitPushTargetPanel {
         if (defaultTarget != null) {
             initialBranch = defaultTarget.getBranch().getNameForRemoteOperations();
         }
-        gerritPushOptionsPanel.getGerritPushExtensionPanel().registerGerritPushTargetPanel(this, initialBranch);
+        gerritPushOptionsPanel.getGerritPushExtensionPanel().registerGerritPushTargetPanel(this, initialBranch, repository);
     }
 
     public void initBranch(final String branch, boolean pushToGerritByDefault) {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritSettingsConfigurable.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritSettingsConfigurable.java
@@ -78,7 +78,8 @@ public class GerritSettingsConfigurable implements SearchableConfigurable, VcsCo
                 !Comparing.equal(gerritSettings.getShowChangeIdColumn(), settingsPane.getShowChangeIdColumn()) ||
                 !Comparing.equal(gerritSettings.getShowTopicColumn(), settingsPane.getShowTopicColumn()) ||
                 !Comparing.equal(gerritSettings.getShowProjectColumn(), settingsPane.getShowProjectColumn()) ||
-                !Comparing.equal(gerritSettings.getCloneBaseUrl(), settingsPane.getCloneBaseUrl(), true));
+                !Comparing.equal(gerritSettings.getCloneBaseUrl(), settingsPane.getCloneBaseUrl(), true) ||
+                !Comparing.equal(gerritSettings.getForceDefaultBranch(), settingsPane.getForceDefaultBranch()));
     }
 
     private boolean isPasswordModified() {
@@ -103,6 +104,7 @@ public class GerritSettingsConfigurable implements SearchableConfigurable, VcsCo
             gerritSettings.setShowTopicColumn(settingsPane.getShowTopicColumn());
             gerritSettings.setShowProjectColumn(settingsPane.getShowProjectColumn());
             gerritSettings.setCloneBaseUrl(settingsPane.getCloneBaseUrl());
+            gerritSettings.setForceDefaultBranch(settingsPane.getForceDefaultBranch());
 
             gerritUpdatesNotificationComponent.handleConfigurationChange();
         }
@@ -125,6 +127,7 @@ public class GerritSettingsConfigurable implements SearchableConfigurable, VcsCo
             settingsPane.setShowTopicColumn(gerritSettings.getShowTopicColumn());
             settingsPane.setShowProjectColumn(gerritSettings.getShowProjectColumn());
             settingsPane.setCloneBaseUrl(gerritSettings.getCloneBaseUrl());
+            settingsPane.setForceDefaultBranch(gerritSettings.getForceDefaultBranch());
         }
     }
 

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/SettingsPanel.form
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/SettingsPanel.form
@@ -3,7 +3,7 @@
   <grid id="9dc44" binding="pane" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="845" height="570"/>
+      <xy x="20" y="20" width="845" height="692"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -22,9 +22,6 @@
               <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
-            <clientProperties>
-              <BorderFactoryClass class="java.lang.String" value="com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent"/>
-            </clientProperties>
             <border type="etched" title="Login"/>
             <children>
               <component id="e76ec" class="javax.swing.JTextField" binding="loginTextField">
@@ -100,15 +97,12 @@
               </component>
             </children>
           </grid>
-          <grid id="d87b1" binding="settingsPane" layout-manager="GridLayoutManager" row-count="11" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="d87b1" binding="settingsPane" layout-manager="GridLayoutManager" row-count="12" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
               <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
             </constraints>
             <properties/>
-            <clientProperties>
-              <BorderFactoryClass class="java.lang.String" value="com.intellij.ui.IdeBorderFactory$PlainSmallWithIndent"/>
-            </clientProperties>
             <border type="etched" title="Settings"/>
             <children>
               <grid id="19e05" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
@@ -284,6 +278,24 @@
                     </constraints>
                     <properties>
                       <text value="Set a clone base URL if it differs from the Gerrit web URL."/>
+                    </properties>
+                  </component>
+                </children>
+              </grid>
+              <grid id="170a3" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                <margin top="0" left="0" bottom="0" right="0"/>
+                <constraints>
+                  <grid row="11" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties/>
+                <border type="none"/>
+                <children>
+                  <component id="7f964" class="javax.swing.JCheckBox" binding="forceDefaultBranchCheckBox">
+                    <constraints>
+                      <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                    </constraints>
+                    <properties>
+                      <text value="Force default branch name"/>
                     </properties>
                   </component>
                 </children>

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/SettingsPanel.form
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/SettingsPanel.form
@@ -295,7 +295,7 @@
                       <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                     </constraints>
                     <properties>
-                      <text value="Force default branch name"/>
+                      <text value="Force default branch name (restart needed to take effect)"/>
                     </properties>
                   </component>
                 </children>

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/SettingsPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/SettingsPanel.java
@@ -63,6 +63,7 @@ public class SettingsPanel {
     private JCheckBox showTopicColumnCheckBox;
     private JComboBox showProjectColumnComboBox;
     private JTextField cloneBaseUrlTextField;
+    private JCheckBox forceDefaultBranchCheckBox;
 
     private boolean passwordModified;
 
@@ -279,6 +280,14 @@ public class SettingsPanel {
 
     public String getCloneBaseUrl() {
         return cloneBaseUrlTextField.getText().trim();
+    }
+
+    public void setForceDefaultBranch(final boolean forceDefaultBranch) {
+        forceDefaultBranchCheckBox.setSelected(forceDefaultBranch);
+    }
+
+    public boolean getForceDefaultBranch() {
+        return forceDefaultBranchCheckBox.isSelected();
     }
 
 }


### PR DESCRIPTION
One main idea of Gerrit's flow is to push on master, with custom git behaviours.
Thus on remote, it is very exceptional to work on another branch.
But locally, it still makes sense to use branches and to push on master.
Especially allows for a nice presentation on Gerrit with the "pushed together commits"

That's why it makes sense for the plugin to force the main branch based on the gitreview file.
But it only covers the case of a single local repo/gerritPushTargetPanel.
For multiple ones, we must type "master" in the branch input each time we push using a local branch.
It happens very often in my case.

Given I'm not sure everyone wants that behaviour (and I tried to understand the codebase), I've added a specific setting