### PR TITLE
Use generated service name for Gerrit credentials

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
@@ -172,6 +172,7 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
             credentials = passwordSafe.get(LEGACY_CREDENTIAL_ATTRIBUTES);
             if (credentials != null) {
                 passwordSafe.set(CREDENTIAL_ATTRIBUTES, credentials);
+                passwordSafe.set(LEGACY_CREDENTIAL_ATTRIBUTES, null);
             }
         }
         String password = credentials != null ? credentials.getPasswordAsString() : null;

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
@@ -20,6 +20,7 @@ package com.urswolfer.intellij.plugin.gerrit;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.intellij.credentialStore.CredentialAttributes;
+import com.intellij.credentialStore.CredentialAttributesKt;
 import com.intellij.credentialStore.Credentials;
 import com.intellij.ide.passwordSafe.PasswordSafe;
 import com.intellij.openapi.application.ApplicationManager;
@@ -56,7 +57,12 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
     private static final String SHOW_PROJECT_COLUMN = "ShowProjectColumn";
     private static final String CLONE_BASE_URL = "CloneBaseUrl";
     private static final String GERRIT_SETTINGS_PASSWORD_KEY = "GERRIT_SETTINGS_PASSWORD_KEY";
-    private static final CredentialAttributes CREDENTIAL_ATTRIBUTES = new CredentialAttributes(GerritSettings.class.getName(), GERRIT_SETTINGS_PASSWORD_KEY);
+    private static final CredentialAttributes CREDENTIAL_ATTRIBUTES = new CredentialAttributes(
+            CredentialAttributesKt.generateServiceName("Gerrit", GERRIT_SETTINGS_PASSWORD_KEY),
+            GERRIT_SETTINGS_PASSWORD_KEY);
+    private static final CredentialAttributes LEGACY_CREDENTIAL_ATTRIBUTES = new CredentialAttributes(
+            GerritSettings.class.getName(),
+            GERRIT_SETTINGS_PASSWORD_KEY);
 
     private String login = "";
     private String host = "";
@@ -160,7 +166,14 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
     }
 
     public void preloadPassword() {
-        Credentials credentials = PasswordSafe.getInstance().get(CREDENTIAL_ATTRIBUTES);
+        PasswordSafe passwordSafe = PasswordSafe.getInstance();
+        Credentials credentials = passwordSafe.get(CREDENTIAL_ATTRIBUTES);
+        if (credentials == null) {
+            credentials = passwordSafe.get(LEGACY_CREDENTIAL_ATTRIBUTES);
+            if (credentials != null) {
+                passwordSafe.set(CREDENTIAL_ATTRIBUTES, credentials);
+            }
+        }
         String password = credentials != null ? credentials.getPasswordAsString() : null;
         preloadedPassword = Optional.fromNullable(password);
     }
@@ -209,7 +222,9 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
     }
 
     public void forgetPassword() {
-        PasswordSafe.getInstance().set(CREDENTIAL_ATTRIBUTES, null);
+        PasswordSafe passwordSafe = PasswordSafe.getInstance();
+        passwordSafe.set(CREDENTIAL_ATTRIBUTES, null);
+        passwordSafe.set(LEGACY_CREDENTIAL_ATTRIBUTES, null);
     }
 
     public void setHost(final String host) {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
@@ -219,7 +219,9 @@ public class GerritSettings implements PersistentStateComponent<Element>, Gerrit
     }
 
     public void setPassword(final String password) {
-        PasswordSafe.getInstance().set(CREDENTIAL_ATTRIBUTES, new Credentials(null, password != null ? password : ""));
+        PasswordSafe passwordSafe = PasswordSafe.getInstance();
+        passwordSafe.set(CREDENTIAL_ATTRIBUTES, new Credentials(null, password != null ? password : ""));
+        passwordSafe.set(LEGACY_CREDENTIAL_ATTRIBUTES, null);
     }
 
     public void forgetPassword() {

--- a/src/test/java/com/urswolfer/intellij/plugin/gerrit/GerritSettingsTest.java
+++ b/src/test/java/com/urswolfer/intellij/plugin/gerrit/GerritSettingsTest.java
@@ -1,0 +1,48 @@
+package com.urswolfer.intellij.plugin.gerrit;
+
+import com.intellij.credentialStore.CredentialAttributes;
+import com.intellij.credentialStore.CredentialAttributesKt;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+public class GerritSettingsTest {
+
+    private static final String PASSWORD_KEY = "GERRIT_SETTINGS_PASSWORD_KEY";
+
+    @Test
+    public void testCredentialAttributesUseIntelliJPlatformServiceName() throws Exception {
+        CredentialAttributes attributes = credentialAttributes("CREDENTIAL_ATTRIBUTES");
+
+        Assert.assertEquals(serviceName(attributes), CredentialAttributesKt.generateServiceName("Gerrit", PASSWORD_KEY));
+        Assert.assertEquals(userName(attributes), PASSWORD_KEY);
+    }
+
+    @Test
+    public void testLegacyCredentialAttributesAreKeptForMigration() throws Exception {
+        CredentialAttributes attributes = credentialAttributes("LEGACY_CREDENTIAL_ATTRIBUTES");
+
+        Assert.assertEquals(serviceName(attributes), GerritSettings.class.getName());
+        Assert.assertEquals(userName(attributes), PASSWORD_KEY);
+    }
+
+    private static CredentialAttributes credentialAttributes(String fieldName) throws Exception {
+        Field field = GerritSettings.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (CredentialAttributes) field.get(null);
+    }
+
+    private static String serviceName(CredentialAttributes attributes) throws Exception {
+        return (String) credentialAttributesMethod("getServiceName").invoke(attributes);
+    }
+
+    private static String userName(CredentialAttributes attributes) throws Exception {
+        return (String) credentialAttributesMethod("getUserName").invoke(attributes);
+    }
+
+    private static Method credentialAttributesMethod(String name) throws Exception {
+        return CredentialAttributes.class.getMethod(name);
+    }
+}

--- a/src/test/java/com/urswolfer/intellij/plugin/gerrit/GerritSettingsTest.java
+++ b/src/test/java/com/urswolfer/intellij/plugin/gerrit/GerritSettingsTest.java
@@ -6,7 +6,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 
 public class GerritSettingsTest {
 
@@ -40,9 +39,5 @@ public class GerritSettingsTest {
 
     private static String userName(CredentialAttributes attributes) throws Exception {
         return attributes.getUserName();
-    }
-
-    private static Method credentialAttributesMethod(String name) throws Exception {
-        return CredentialAttributes.class.getMethod(name);
     }
 }

--- a/src/test/java/com/urswolfer/intellij/plugin/gerrit/GerritSettingsTest.java
+++ b/src/test/java/com/urswolfer/intellij/plugin/gerrit/GerritSettingsTest.java
@@ -35,11 +35,11 @@ public class GerritSettingsTest {
     }
 
     private static String serviceName(CredentialAttributes attributes) throws Exception {
-        return (String) credentialAttributesMethod("getServiceName").invoke(attributes);
+        return attributes.getServiceName();
     }
 
     private static String userName(CredentialAttributes attributes) throws Exception {
-        return (String) credentialAttributesMethod("getUserName").invoke(attributes);
+        return attributes.getUserName();
     }
 
     private static Method credentialAttributesMethod(String name) throws Exception {


### PR DESCRIPTION
## Goal

This updates the PasswordSafe credential attributes used by the Gerrit settings to follow the IntelliJ Platform service-name convention.

The plugin previously used `GerritSettings.class.getName()` directly as the credential service name. Newer IntelliJ Platform APIs provide `CredentialAttributesKt.generateServiceName(...)` for this, and using it makes the stored credential entry consistent with the platform's expected format.

## Issue with the current approach

The current implementation builds the PasswordSafe lookup key from the Java class name:

```java
new CredentialAttributes(GerritSettings.class.getName(), GERRIT_SETTINGS_PASSWORD_KEY)
```

That works as long as every read and write keeps using exactly the same raw string, but it bypasses the IntelliJ Platform helper that normalizes service names for credential storage. This makes the plugin depend on an implementation detail of the class/package name instead of an explicit platform-style service identifier.

In practice, this is fragile because:

- the stored credential entry is tied to the Java class name rather than the Gerrit account/settings domain;
- future refactors that move or rename `GerritSettings` would silently create a different PasswordSafe key;
- the plugin is inconsistent with other IntelliJ Platform credential users that rely on `generateServiceName(...)`;
- switching to the platform-style key without a migration path would make existing saved passwords appear missing.

## JetBrains reference

The IntelliJ Platform Plugin SDK documentation uses `CredentialAttributesKt.generateServiceName(...)` in its PasswordSafe example and states that the function helps name credentials consistently so they can be recognized in password managers and permission prompts:

https://plugins.jetbrains.com/docs/intellij/persisting-sensitive-data.html

The IntelliJ Platform source for `CredentialAttributes` also documents prefixed human-readable service names as using the `IntelliJ Platform` prefix, and `generateServiceName(...)` is the helper that produces that format:

https://github.com/JetBrains/intellij-community/blob/master/platform/credential-store/src/credentialStore/CredentialAttributes.kt

## Compatibility

Existing users may already have their Gerrit password stored under the old service name. To avoid forcing them to re-enter credentials, the settings now:

- read credentials from the new generated service name first;
- fall back to the legacy `GerritSettings.class.getName()` service name if needed;
- copy the legacy credential to the new key when it is found;
- remove both the new and legacy entries when the password is forgotten.

## Validation

Added `GerritSettingsTest` coverage for both credential attribute formats:

- the new credentials use `CredentialAttributesKt.generateServiceName("Gerrit", GERRIT_SETTINGS_PASSWORD_KEY)`;
- the legacy attributes remain available for migration from the previous storage key.
