### PR TITLE
Fix Gerrit checkout/fetch failing under WSL2, fixes #408

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/git/GerritGitUtil.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/git/GerritGitUtil.java
@@ -70,6 +70,7 @@ import git4idea.repo.GitRepositoryManager;
 import git4idea.util.GitUntrackedFilesHelper;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -143,22 +144,20 @@ public class GerritGitUtil {
         GitVcs.runInBackground(new Task.Backgroundable(project, "Fetching...", false) {
             @Override
             public void run(@NotNull ProgressIndicator indicator) {
-                GitRemote remote;
-                String fetch;
                 boolean commitIsFetched = checkIfCommitIsFetched(gitRepository, commitHash);
-                if (commitIsFetched) {
-                    // 'git fetch' works with a local path instead of a remote -> this way FETCH_HEAD is set
-                    remote = new GitRemote(gitRepository.getRoot().getPath(),
-                        Collections.<String>emptyList(), Collections.<String>emptySet(), Collections.<String>emptyList(), Collections.<String>emptyList());
-                    fetch = commitHash;
-                } else {
-                    remote = getRemoteForChange(project, gitRepository, fetchInfo).orNull();
-                    if (remote == null) {
-                        return;
-                    }
-                    fetch = fetchInfo.ref;
+                Optional<Pair<GitRemote, String>> fetchTarget = determineFetchTarget(
+                    project,
+                    gitRepository,
+                    fetchInfo,
+                    commitHash,
+                    commitIsFetched
+                );
+                if (!fetchTarget.isPresent()) {
+                    return;
                 }
-                GitFetchResult result = GitFetchSupport.fetchSupport(project).fetch(gitRepository, remote, fetch);
+
+                Pair<GitRemote, String> target = fetchTarget.get();
+                GitFetchResult result = GitFetchSupport.fetchSupport(project).fetch(gitRepository, target.first, target.second);
                 result.showNotificationIfFailed();
 
                 try {
@@ -170,6 +169,36 @@ public class GerritGitUtil {
                  }
             }
         });
+    }
+
+    @VisibleForTesting
+    Optional<Pair<GitRemote, String>> determineFetchTarget(
+        Project project,
+        GitRepository gitRepository,
+        FetchInfo fetchInfo,
+        String commitHash,
+        boolean commitIsFetched
+    ) {
+        if (commitIsFetched) {
+            return Optional.of(Pair.create(createSelfFetchRemote(), commitHash));
+        }
+
+        return getRemoteForChange(project, gitRepository, fetchInfo).transform(remote -> Pair.create(remote, fetchInfo.ref));
+    }
+
+    private static GitRemote createSelfFetchRemote() {
+        // fetch from "." (the repo's own working directory) instead of an absolute path: under WSL2,
+        // IntelliJ's absolute path is a Windows UNC path that's meaningless to git running inside the
+        // Linux subsystem, while "." always resolves correctly since it's relative to the process's cwd
+        String workingDirectory = ".";
+
+        return new GitRemote(
+            workingDirectory,
+            Collections.emptyList(),
+            Collections.emptySet(),
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
     }
 
     public void cherryPickChange(final Project project, final ChangeInfo changeInfo, final String revisionId) {

--- a/src/test/java/com/urswolfer/intellij/plugin/gerrit/git/GerritGitUtilTest.java
+++ b/src/test/java/com/urswolfer/intellij/plugin/gerrit/git/GerritGitUtilTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2013-2015 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.urswolfer.intellij.plugin.gerrit.git;
+
+import com.google.common.base.Optional;
+import com.google.gerrit.extensions.common.FetchInfo;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Pair;
+import git4idea.repo.GitRemote;
+import git4idea.repo.GitRepository;
+import org.easymock.EasyMock;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+public class GerritGitUtilTest {
+
+    @Test
+    public void testDetermineFetchTargetUsesSelfPathWhenCommitAlreadyFetched() {
+        GerritGitUtil gerritGitUtil = new GerritGitUtil();
+
+        GitRepository gitRepository = EasyMock.createMock(GitRepository.class);
+        EasyMock.replay(gitRepository);
+
+        Optional<Pair<GitRemote, String>> fetchTarget = gerritGitUtil.determineFetchTarget(
+            null,
+            gitRepository,
+            null,
+            "abcd1234",
+            true
+        );
+
+        Assert.assertTrue(fetchTarget.isPresent());
+        Pair<GitRemote, String> target = fetchTarget.get();
+        Assert.assertEquals(target.first.getName(), ".");
+        Assert.assertEquals(target.second, "abcd1234");
+
+        EasyMock.verify(gitRepository);
+    }
+
+    @Test
+    public void testDetermineFetchTargetResolvesRemoteWhenCommitNotYetFetched() {
+        GerritGitUtil gerritGitUtil = new GerritGitUtil();
+
+        String gerritUrl = "https://gerrit.example.com/myProject";
+        GitRemote origin = new GitRemote(
+            "origin",
+            Collections.singletonList(gerritUrl),
+            Collections.emptySet(),
+            Collections.emptyList(),
+            Collections.emptyList()
+        );
+
+        GitRepository gitRepository = EasyMock.createMock(GitRepository.class);
+        EasyMock.expect(gitRepository.getRemotes()).andReturn(Collections.singletonList(origin)).anyTimes();
+        EasyMock.replay(gitRepository);
+        FetchInfo fetchInfo = new FetchInfo(gerritUrl, "refs/changes/34/1234/1");
+        Project project = EasyMock.createMock(Project.class);
+
+        Optional<Pair<GitRemote, String>> fetchTarget = gerritGitUtil.determineFetchTarget(
+            project,
+            gitRepository,
+            fetchInfo,
+            "abcd1234",
+            false
+        );
+
+        Assert.assertTrue(fetchTarget.isPresent());
+        Pair<GitRemote, String> target = fetchTarget.get();
+        Assert.assertSame(target.first, origin);
+        Assert.assertEquals(target.second, "refs/changes/34/1234/1");
+    }
+}


### PR DESCRIPTION
Point the local self-fetch trick at `"."` instead of the repository's absolute path. Under WSL2, that path is a Windows UNC path (`//wsl$/...` or `//wsl.localhost/...`), which is meaningless to git running inside the Linux subsystem, so fetch/checkout/cherry-pick/compare-branch would fail with "does not appear to be a git repository".

Furthermore, extract the fetching logic into a  method to have it testable in the `GerritGitUtilTest.java`.