### PR TITLE
Remove obsolete "Drafts" status filter (is:draft)

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/StatusFilter.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/StatusFilter.java
@@ -39,8 +39,7 @@ public class StatusFilter extends AbstractChangesFilter {
             new Status("All", null),
             new Status("Open", "open"),
             new Status("Merged", "merged"),
-            new Status("Abandoned", "abandoned"),
-            new Status("Drafts", "draft")
+            new Status("Abandoned", "abandoned")
     );
 
     private static final Supplier<String> QUERY_FOR_ALL = new Supplier<String>() {


### PR DESCRIPTION
Gerrit 2.15 removed draft changes (replaced by WIP / private flags), so the "is:draft" query operator is no longer recognized. Since the "All" status expands to "(is:open OR is:merged OR is:abandoned OR is:draft)", both "All" and "Drafts" fail against any Gerrit >= 2.15 with HTTP 400 "Unrecognized value: draft." and the changes list stays empty.

Drop the "Drafts" entry, so "All" becomes "(is:open OR is:merged OR is:abandoned)". WIP changes are already covered by the separate "WIP Changes" toggle (ShowWIPFilter, #481).

Fixes #453, fixes #524 (the status:{all,draft} part).