### PR TITLE
Do not invoke override-only SubmitAction.actionPerformed

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/ReviewAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/ReviewAction.java
@@ -127,7 +127,7 @@ public class ReviewAction extends AbstractLoggedInChangeAction {
                                         .hideBalloon();
                                 notificationService.notifyInformation(notification);
                                 if (finalSubmitChange) {
-                                    submitAction.actionPerformed(anActionEvent);
+                                    submitAction.submit(anActionEvent);
                                 }
                             }
                         }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/SubmitAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/SubmitAction.java
@@ -56,6 +56,11 @@ public class SubmitAction extends AbstractLoggedInChangeAction {
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent) {
+        submit(anActionEvent);
+    }
+
+    /** Entry point for other actions; {@code actionPerformed} is override-only and must not be invoked. */
+    public void submit(AnActionEvent anActionEvent) {
         final Project project = anActionEvent.getData(PlatformDataKeys.PROJECT);
 
         final Optional<ChangeInfo> selectedChange = getSelectedChange(anActionEvent);
@@ -92,7 +97,12 @@ public class SubmitAction extends AbstractLoggedInChangeAction {
 
         @Override
         public void actionPerformed(AnActionEvent e) {
-            delegate.actionPerformed(e);
+            delegate.submit(e);
+        }
+
+        @Override
+        public void submit(AnActionEvent e) {
+            delegate.submit(e);
         }
     }
 }


### PR DESCRIPTION
Fixes the plugin verifier's `override-only API usage violation`.

`AnAction.actionPerformed` is `@ApiStatus.OverrideOnly`, but `ReviewAction` invoked `SubmitAction.actionPerformed(AnActionEvent)` directly. The submit logic moves into a plain `SubmitAction.submit(AnActionEvent)` that `actionPerformed` delegates to; `ReviewAction` calls that instead.

`SubmitAction.Proxy.actionPerformed` also called `delegate.actionPerformed(e)`. The verifier does not flag that (it exempts a subclass delegating to the class it extends, which is why the same pattern in `CheckoutAction`, `AbandonAction` etc. is not reported), but it is switched to `delegate.submit(e)` so no call to `actionPerformed` remains.

No behaviour change: `ReviewActionFactory` injects the Guice-bound `SubmitAction` (`GerritActionsModule` binds the class, not the `Proxy`), so `gerritUtil`/`notificationService` are wired as before.

This needs no platform baseline bump. `ActionUtil.performAction` would require 2025.2 (and therefore Java 21), and `ActionUtil.performActionDumbAwareWithCallbacks` would require 2021.2 and is already deprecated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Usxh7oZHXBcCr7GVt998bn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Usxh7oZHXBcCr7GVt998bn)_