### PR TITLE
Replace internal ActionsBundle with public VcsBundle

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/GerritUtil.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/GerritUtil.java
@@ -40,7 +40,6 @@ import com.google.gerrit.extensions.common.RevisionInfo;
 import com.google.gerrit.extensions.restapi.RestApiException;
 import com.google.gerrit.extensions.restapi.Url;
 import com.google.inject.Inject;
-import com.intellij.idea.ActionsBundle;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationListener;
 import com.intellij.openapi.application.ApplicationManager;
@@ -52,6 +51,7 @@ import com.intellij.openapi.progress.Task;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.ThrowableComputable;
+import com.intellij.openapi.vcs.VcsBundle;
 import com.intellij.util.Consumer;
 import com.urswolfer.gerrit.client.rest.GerritAuthData;
 import com.urswolfer.gerrit.client.rest.GerritRestApi;
@@ -439,7 +439,8 @@ public class GerritUtil {
                     @Override
                     public void hyperlinkUpdate(@NotNull Notification notification, @NotNull HyperlinkEvent event) {
                         if (event.getEventType() == HyperlinkEvent.EventType.ACTIVATED && event.getDescription().equals("vcs")) {
-                            ShowSettingsUtil.getInstance().showSettingsDialog(project, ActionsBundle.message("group.VcsGroup.text"));
+                            ShowSettingsUtil.getInstance().showSettingsDialog(project,
+                                    VcsBundle.message("version.control.main.configurable.name"));
                         }
                     }
                 });


### PR DESCRIPTION
Fixes both `internal API usage` findings reported by the plugin verifier (an internal class reference and an internal method invocation — the same single call site).

`com.intellij.idea.ActionsBundle` became `@ApiStatus.Internal` in 2026.2 (it is un-annotated in 2026.1 and older). Replaced with `VcsBundle.message("version.control.main.configurable.name")`:

- `com.intellij.openapi.vcs.VcsBundle` (`vcs-api-core`) is public API in 2020.3 through 2026.2 and master.
- That key is the one the Version Control root configurable is registered under (`platform/vcs-impl/resources/META-INF/VcsExtensions.xml`: `<projectConfigurable groupId="root" key="version.control.main.configurable.name">`), so `showSettingsDialog(project, name)` still opens the same page. Both keys resolve to `Version Control`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Usxh7oZHXBcCr7GVt998bn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Usxh7oZHXBcCr7GVt998bn)_