### PR TITLE
Replace deprecated java.util.Observable/Observer

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/SelectedRevisions.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/SelectedRevisions.java
@@ -20,9 +20,11 @@ import com.google.common.base.Optional;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.gerrit.extensions.common.ChangeInfo;
+import com.intellij.util.EventDispatcher;
+import org.jetbrains.annotations.Nullable;
 
+import java.util.EventListener;
 import java.util.Map;
-import java.util.Observable;
 import java.util.Set;
 
 /**
@@ -30,8 +32,13 @@ import java.util.Set;
  *
  * @author Thomas Forrer
  */
-public class SelectedRevisions extends Observable {
+public class SelectedRevisions {
     private final Map<String, String> map = Maps.newHashMap();
+    private final EventDispatcher<Listener> eventDispatcher = EventDispatcher.create(Listener.class);
+
+    public void addListener(Listener listener) {
+        eventDispatcher.addListener(listener);
+    }
 
     /**
      * @return the selected revision for the provided changeId, or {@link com.google.common.base.Optional#absent()} if
@@ -59,13 +66,19 @@ public class SelectedRevisions extends Observable {
 
     public void put(String changeId, String revisionHash) {
         map.put(changeId, revisionHash);
-        setChanged();
-        notifyObservers(changeId);
+        eventDispatcher.getMulticaster().selectedRevisionChanged(changeId);
     }
 
     public void clear() {
         map.clear();
-        setChanged();
-        notifyObservers();
+        eventDispatcher.getMulticaster().selectedRevisionChanged(null);
+    }
+
+    public interface Listener extends EventListener {
+        /**
+         * @param changeId the change for which the selected revision changed, or {@code null} if all selections were
+         *                 cleared
+         */
+        void selectedRevisionChanged(@Nullable String changeId);
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritCommentCountChangeNodeDecorator.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritCommentCountChangeNodeDecorator.java
@@ -63,10 +63,10 @@ public class GerritCommentCountChangeNodeDecorator implements GerritChangeNodeDe
     @Inject
     public GerritCommentCountChangeNodeDecorator(SelectedRevisions selectedRevisions) {
         this.selectedRevisions = selectedRevisions;
-        this.selectedRevisions.addObserver(new Observer() {
+        this.selectedRevisions.addListener(new SelectedRevisions.Listener() {
             @Override
-            public void update(Observable o, Object arg) {
-                if (arg instanceof String && selectedChange != null && selectedChange.id.equals(arg)) {
+            public void selectedRevisionChanged(String changeId) {
+                if (changeId != null && selectedChange != null && selectedChange.id.equals(changeId)) {
                     refreshSuppliers();
                 }
             }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritToolWindow.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritToolWindow.java
@@ -44,8 +44,6 @@ import git4idea.repo.GitRepository;
 
 import javax.swing.*;
 import java.util.List;
-import java.util.Observable;
-import java.util.Observer;
 
 /**
  * @author Urs Wolfer
@@ -162,9 +160,9 @@ public class GerritToolWindow {
         filterGroup.add(new Separator());
         group.add(filterGroup, Constraints.FIRST);
 
-        changesFilters.addObserver(new Observer() {
+        changesFilters.addListener(new GerritChangesFilters.Listener() {
             @Override
-            public void update(Observable observable, Object o) {
+            public void filtersChanged() {
                 reloadChanges(project, true);
             }
         });

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/RepositoryChangesBrowserProvider.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/RepositoryChangesBrowserProvider.java
@@ -61,8 +61,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Observable;
-import java.util.Observer;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
@@ -119,10 +117,10 @@ public class RepositoryChangesBrowserProvider {
                     updateChangesBrowser();
                 }
             });
-            selectedRevisions.addObserver(new Observer() {
+            selectedRevisions.addListener(new SelectedRevisions.Listener() {
                 @Override
-                public void update(Observable o, Object arg) {
-                    if (arg != null && arg instanceof String && selectedChange != null && selectedChange.id.equals(arg)) {
+                public void selectedRevisionChanged(String changeId) {
+                    if (changeId != null && selectedChange != null && selectedChange.id.equals(changeId)) {
                         updateChangesBrowser();
                     }
                 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/changesbrowser/SelectBaseRevisionAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/changesbrowser/SelectBaseRevisionAction.java
@@ -38,8 +38,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Observable;
-import java.util.Observer;
 
 /**
  * @author Thomas Forrer
@@ -65,11 +63,11 @@ public class SelectBaseRevisionAction extends BasePopupAction {
     public SelectBaseRevisionAction(final SelectedRevisions selectedRevisions) {
         super("Diff against");
         this.selectedRevisions = selectedRevisions;
-        selectedRevisions.addObserver(new Observer() {
+        selectedRevisions.addListener(new SelectedRevisions.Listener() {
             @Override
-            public void update(Observable o, Object arg) {
-                if (arg != null && arg instanceof String && selectedValue.isPresent() ) {
-                    Optional<String> selectedRevision = selectedRevisions.get((String) arg);
+            public void selectedRevisionChanged(String changeId) {
+                if (changeId != null && selectedValue.isPresent()) {
+                    Optional<String> selectedRevision = selectedRevisions.get(changeId);
                     if (selectedRevision.isPresent() && selectedRevision.get().equals(selectedValue.get().getFirst())) {
                         removeSelectedValue();
                         updateLabel();

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/AbstractChangesFilter.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/AbstractChangesFilter.java
@@ -16,10 +16,25 @@
 
 package com.urswolfer.intellij.plugin.gerrit.ui.filter;
 
-import java.util.Observable;
+import com.intellij.util.EventDispatcher;
+
+import java.util.EventListener;
 
 /**
  * @author Thomas Forrer
  */
-public abstract class AbstractChangesFilter extends Observable implements ChangesFilter  {
+public abstract class AbstractChangesFilter implements ChangesFilter  {
+    private final EventDispatcher<Listener> eventDispatcher = EventDispatcher.create(Listener.class);
+
+    public void addListener(Listener listener) {
+        eventDispatcher.addListener(listener);
+    }
+
+    protected void fireFilterChanged() {
+        eventDispatcher.getMulticaster().filterChanged();
+    }
+
+    public interface Listener extends EventListener {
+        void filterChanged();
+    }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/AbstractUserFilter.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/AbstractUserFilter.java
@@ -64,7 +64,7 @@ public abstract class AbstractUserFilter extends AbstractChangesFilter {
                 new User("Me", "self")
         );
         value = Optional.of(users.get(0));
-        return new UserPopupAction(project, getActionLabel());
+        return new UserPopupAction(getActionLabel());
     }
 
     @Override
@@ -90,11 +90,8 @@ public abstract class AbstractUserFilter extends AbstractChangesFilter {
     }
 
     public final class UserPopupAction extends BasePopupAction {
-        private final Project project;
-
-        public UserPopupAction(Project project, String labelText) {
+        public UserPopupAction(String labelText) {
             super(labelText);
-            this.project = project;
             updateFilterValueLabel(value.get().label);
         }
 
@@ -135,8 +132,7 @@ public abstract class AbstractUserFilter extends AbstractChangesFilter {
         private void change(User user) {
             value = Optional.of(user);
             updateFilterValueLabel(user.label);
-            setChanged();
-            notifyObservers(project);
+            fireFilterChanged();
         }
 
         private AnAction buildOkAction() {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/BranchFilter.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/BranchFilter.java
@@ -81,8 +81,7 @@ public class BranchFilter extends AbstractChangesFilter {
                 public void actionPerformed(AnActionEvent e) {
                     value = Optional.absent();
                     updateFilterValueLabel("All");
-                    setChanged();
-                    notifyObservers(project);
+                    fireFilterChanged();
                 }
             });
             Iterable<GitRepository> repositories = gerritGitUtil.getRepositories(project);
@@ -94,8 +93,7 @@ public class BranchFilter extends AbstractChangesFilter {
                     public void actionPerformed(AnActionEvent e) {
                         value = Optional.of(new BranchDescriptor(repository));
                         updateFilterValueLabel(String.format("All (%s)", getNameForRepository(repository)));
-                        setChanged();
-                        notifyObservers(project);
+                        fireFilterChanged();
                     }
                 });
                 List<GitRemoteBranch> branches = Lists.newArrayList(repository.getBranches().getRemoteBranches());
@@ -113,8 +111,7 @@ public class BranchFilter extends AbstractChangesFilter {
                             public void actionPerformed(AnActionEvent e) {
                                 value = Optional.of(new BranchDescriptor(repository, branch));
                                 updateFilterValueLabel(String.format("%s (%s)", branch.getNameForRemoteOperations(), getNameForRepository(repository)));
-                                setChanged();
-                                notifyObservers(project);
+                                fireFilterChanged();
                             }
                         });
                     }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/FulltextFilter.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/FulltextFilter.java
@@ -37,8 +37,7 @@ public class FulltextFilter extends AbstractChangesFilter {
                 String newValue = getText().trim();
                 if (isNewValue(newValue)) {
                     value = newValue;
-                    setChanged();
-                    notifyObservers(project);
+                    fireFilterChanged();
                 }
             }
 

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/GerritChangesFilters.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/GerritChangesFilters.java
@@ -21,29 +21,33 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
+import com.intellij.util.EventDispatcher;
 
-import java.util.Observable;
-import java.util.Observer;
+import java.util.EventListener;
 import java.util.Set;
 
 /**
  * @author Thomas Forrer
  */
-public class GerritChangesFilters extends Observable implements Observer {
+public class GerritChangesFilters implements AbstractChangesFilter.Listener {
     private final Set<AbstractChangesFilter> filters;
+    private final EventDispatcher<Listener> eventDispatcher = EventDispatcher.create(Listener.class);
 
     @Inject
     public GerritChangesFilters(Set<AbstractChangesFilter> filters) {
         this.filters = filters;
         for (AbstractChangesFilter filter : this.filters) {
-            filter.addObserver(this);
+            filter.addListener(this);
         }
     }
 
+    public void addListener(Listener listener) {
+        eventDispatcher.addListener(listener);
+    }
+
     @Override
-    public void update(Observable observable, Object o) {
-        setChanged();
-        notifyObservers();
+    public void filterChanged() {
+        eventDispatcher.getMulticaster().filtersChanged();
     }
 
     public String getQuery() {
@@ -58,5 +62,9 @@ public class GerritChangesFilters extends Observable implements Observer {
 
     public Iterable<ChangesFilter> getFilters() {
         return ImmutableList.<ChangesFilter>copyOf(filters);
+    }
+
+    public interface Listener extends EventListener {
+        void filtersChanged();
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/IsStarredFilter.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/IsStarredFilter.java
@@ -38,8 +38,7 @@ public class IsStarredFilter extends AbstractChangesFilter {
 
     private void setValue(boolean value) {
         this.value = value;
-        setChanged();
-        notifyObservers();
+        fireFilterChanged();
     }
 
     @Nullable

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/ShowWIPFilter.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/ShowWIPFilter.java
@@ -38,8 +38,7 @@ public class ShowWIPFilter extends AbstractChangesFilter {
 
     private void setValue(boolean value) {
         this.value = value;
-        setChanged();
-        notifyObservers();
+        fireFilterChanged();
     }
 
     @Nullable

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/StatusFilter.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/StatusFilter.java
@@ -63,7 +63,7 @@ public class StatusFilter extends AbstractChangesFilter {
 
     @Override
     public AnAction getAction(final Project project) {
-        return new StatusPopupAction(project, "Status");
+        return new StatusPopupAction("Status");
     }
 
     @Override
@@ -91,11 +91,8 @@ public class StatusFilter extends AbstractChangesFilter {
     }
 
     public final class StatusPopupAction extends BasePopupAction {
-        private final Project project;
-
-        public StatusPopupAction(Project project, String labelText) {
+        public StatusPopupAction(String labelText) {
             super(labelText);
-            this.project = project;
             updateFilterValueLabel(value.get().label);
         }
 
@@ -107,8 +104,7 @@ public class StatusFilter extends AbstractChangesFilter {
                     public void actionPerformed(AnActionEvent e) {
                         value = Optional.of(status);
                         updateFilterValueLabel(status.label);
-                        setChanged();
-                        notifyObservers(project);
+                        fireFilterChanged();
                     }
                 });
             }


### PR DESCRIPTION
Clears 16 of the 61 deprecated API usages the verifier reports: `java.util.Observable` (11) and `java.util.Observer` (5). JDK deprecations (since Java 9), so no platform baseline change.

Uses the platform's `com.intellij.util.EventDispatcher` with a listener interface per event source, which is how the platform does this itself (for example `ChangeListManagerImpl` holds `EventDispatcher.create(ChangeListListener::class.java)`):

- `SelectedRevisions.Listener.selectedRevisionChanged(changeId)` — `null` when all selections are cleared, matching what `clear()` used to pass
- `AbstractChangesFilter.Listener.filterChanged()`
- `GerritChangesFilters.Listener.filtersChanged()`

`EventDispatcher` is in `platform/util`, public and unannotated, with the same `create`/`getMulticaster`/`addListener`/`removeListener` surface in 2020.3 and in master, so it is safe against the whole supported range.

Notes:

- Typed events let the four listeners drop their `arg instanceof String` checks and casts.
- `setChanged()` has no equivalent and is gone. Every `notifyObservers()` call was already immediately preceded by `setChanged()`, so delivery is unchanged.
- The filter event carried a `Project` that its only listener never read. It is gone, and with it the `project` fields in `UserPopupAction` and `StatusPopupAction` that existed solely to supply it (their constructors lose the parameter). `BranchPopupAction` keeps its field — it uses it for something else.
- Listeners fire in registration order, and `EventDispatcher` also swallows/logs exceptions per listener instead of letting one break the notification loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Usxh7oZHXBcCr7GVt998bn