### PR TITLE
Upgrade Java version from 11 to 17 in CI workflows

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v5
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v5
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v5


### PR DESCRIPTION
## Summary
This pull request updates the Java Development Kit (JDK) version used in the CI/CD pipelines from Java 11 to Java 17.

## Key Changes
- Updated `gradle.yml` workflow to use JDK 17 instead of JDK 11
- Updated `release.yml` workflow to use JDK 17 instead of JDK 11
- Both workflows now specify `java-version: 17` in the setup-java action configuration

## Details
The Java version upgrade affects both the standard build workflow and the release workflow, ensuring consistent Java 17 runtime across all CI/CD operations. The Temurin distribution remains unchanged as the JDK provider.

https://claude.ai/code/session_01Sf8GL1PYXFLbTGgEG6wMAy