### PR TITLE
Bump GitHub Actions versions in CI workflows

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,13 +11,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up JDK 17
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         java-version: 17
         distribution: 'temurin'
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@v6
     - name: Execute Gradle build
       run: ./gradlew build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,19 +9,19 @@ jobs:
   build-and-release:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v7
     - name: Set up JDK 17
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@v6
       with:
         java-version: 17
         distribution: 'temurin'
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@v6
     - name: Execute Gradle build
       run: ./gradlew build
 
     - name: Create Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         files: build/distributions/gerrit-intellij-plugin-*.zip
       env:


### PR DESCRIPTION
## Summary
Bumps the GitHub Actions used in the CI and release workflows to their latest major versions.

## Key Changes
- `actions/checkout` v5 -> v7
- `actions/setup-java` v5 -> v6
- `gradle/actions/setup-gradle` v5 -> v6
- `softprops/action-gh-release` v2 -> v3

Applied consistently across `.github/workflows/gradle.yml` and `.github/workflows/release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FABErVRt5LPMX95mihu4Ct

---
_Generated by [Claude Code](https://claude.ai/code/session_01FABErVRt5LPMX95mihu4Ct)_