### PR TITLE
Migrate off deprecated plugin components

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtension.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtension.java
@@ -17,13 +17,10 @@
 package com.urswolfer.intellij.plugin.gerrit.push;
 
 import com.google.inject.Inject;
-import com.intellij.openapi.components.NamedComponent;
 import com.intellij.openapi.diagnostic.Logger;
-import com.urswolfer.intellij.plugin.gerrit.GerritModule;
 import com.urswolfer.intellij.plugin.gerrit.GerritSettings;
 import git4idea.push.GitPushOperation;
 import javassist.*;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Since there are no entry points for modifying the push dialog without copying a lot of source, some modifications
@@ -33,10 +30,12 @@ import org.jetbrains.annotations.NotNull;
  * * Some methods of GitPushSupport are overwritten in order to inject Gerrit push support.
  * * GerritPushExtensionPanel, GerritPushOptionsPanel and GerritPushTargetPanel get copied to the Git plugin class loader.
  *
+ * The byte-code modifications are triggered by instantiating this class, which {@link GerritPushExtensionStarter}
+ * does on application startup.
+ *
  * @author Urs Wolfer
  */
-@SuppressWarnings("ComponentNotRegistered") // proxy class below is registered
-public class GerritPushExtension implements NamedComponent {
+public class GerritPushExtension {
 
     @Inject
     private GerritSettings gerritSettings;
@@ -127,26 +126,6 @@ public class GerritPushExtension implements NamedComponent {
             log.error("Failed to load class required for Gerrit push UI injections.", e);
         } catch (NotFoundException e) {
             log.error("Failed to load class required for Gerrit push UI injections.", e);
-        }
-    }
-
-    @NotNull
-    public String getComponentName() {
-        return "GerritPushExtension";
-    }
-
-
-    public static final class Proxy implements NamedComponent {
-        private final GerritPushExtension delegate;
-
-        public Proxy() {
-            delegate = GerritModule.getInstance(GerritPushExtension.class);
-        }
-
-        @NotNull
-        @Override
-        public String getComponentName() {
-            return delegate.getComponentName();
         }
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionStarter.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionStarter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013-2014 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.urswolfer.intellij.plugin.gerrit.push;
+
+import com.intellij.ide.AppLifecycleListener;
+import com.urswolfer.intellij.plugin.gerrit.GerritModule;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+/**
+ * Instantiating {@link GerritPushExtension} runs its byte-code modifications, which have to be applied before the Git
+ * push dialog is built for the first time.
+ *
+ * @author Urs Wolfer
+ */
+public class GerritPushExtensionStarter implements AppLifecycleListener {
+
+    @Override
+    public void appFrameCreated(@NotNull List<String> commandLineArgs) {
+        GerritModule.getInstance(GerritPushExtension.class);
+    }
+}

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationComponent.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationComponent.java
@@ -49,7 +49,8 @@ public class GerritUpdatesNotificationComponent implements Consumer<List<ChangeI
     private Set<String> notifiedChanges = new HashSet<String>();
     private volatile Project project;
 
-    public synchronized void projectOpened() {
+    public synchronized void projectOpened(Project project) {
+        this.project = project;
         handleNotification();
         setupRefreshTask();
     }
@@ -126,10 +127,6 @@ public class GerritUpdatesNotificationComponent implements Consumer<List<ChangeI
             }
             timer.schedule(new CheckReviewTask(timer), refreshTimeout * 60 * 1000);
         }
-    }
-
-    public void setProject(Project project) {
-        this.project = project;
     }
 
     /** Ignores a task whose timer has been cancelled or replaced meanwhile, which would double the polling. */

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationComponent.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationComponent.java
@@ -124,7 +124,7 @@ public class GerritUpdatesNotificationComponent implements Consumer<List<ChangeI
             if (timer == null) {
                 timer = new Timer();
             }
-            timer.schedule(new CheckReviewTask(), refreshTimeout * 60 * 1000);
+            timer.schedule(new CheckReviewTask(timer), refreshTimeout * 60 * 1000);
         }
     }
 
@@ -132,18 +132,24 @@ public class GerritUpdatesNotificationComponent implements Consumer<List<ChangeI
         this.project = project;
     }
 
-    /** No-op once the task has been cancelled, so a closed project does not resurrect its timer. */
-    private synchronized void rescheduleRefreshTask() {
-        if (timer != null) {
+    /** Ignores a task whose timer has been cancelled or replaced meanwhile, which would double the polling. */
+    private synchronized void rescheduleRefreshTask(Timer scheduledBy) {
+        if (timer == scheduledBy) {
             setupRefreshTask();
         }
     }
 
     private class CheckReviewTask extends TimerTask {
+        private final Timer scheduledBy;
+
+        private CheckReviewTask(Timer scheduledBy) {
+            this.scheduledBy = scheduledBy;
+        }
+
         @Override
         public void run() {
             handleNotification();
-            rescheduleRefreshTask();
+            rescheduleRefreshTask(scheduledBy);
         }
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationComponent.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationComponent.java
@@ -19,15 +19,12 @@ package com.urswolfer.intellij.plugin.gerrit.ui;
 import com.google.common.base.Strings;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.google.inject.Inject;
-import com.intellij.openapi.components.ProjectComponent;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.Consumer;
-import com.urswolfer.intellij.plugin.gerrit.GerritModule;
 import com.urswolfer.intellij.plugin.gerrit.GerritSettings;
 import com.urswolfer.intellij.plugin.gerrit.rest.GerritUtil;
 import com.urswolfer.intellij.plugin.gerrit.util.NotificationBuilder;
 import com.urswolfer.intellij.plugin.gerrit.util.NotificationService;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.HashSet;
 import java.util.List;
@@ -36,10 +33,11 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 /**
+ * Driven by {@link GerritUpdatesNotificationStartupActivity}.
+ *
  * @author Urs Wolfer
  */
-@SuppressWarnings("ComponentNotRegistered") // proxy class below is registered
-public class GerritUpdatesNotificationComponent implements ProjectComponent, Consumer<List<ChangeInfo>> {
+public class GerritUpdatesNotificationComponent implements Consumer<List<ChangeInfo>> {
     @Inject
     private GerritUtil gerritUtil;
     @Inject
@@ -51,22 +49,14 @@ public class GerritUpdatesNotificationComponent implements ProjectComponent, Con
     private Set<String> notifiedChanges = new HashSet<String>();
     private Project project;
 
-    @Override
     public void projectOpened() {
         handleNotification();
         setupRefreshTask();
     }
 
-    @Override
     public void projectClosed() {
         cancelPendingNotificationTasks();
         notifiedChanges.clear();
-    }
-
-    @NotNull
-    @Override
-    public String getComponentName() {
-        return "GerritUpdatesNotificationComponent";
     }
 
     public void handleConfigurationChange() {
@@ -151,38 +141,6 @@ public class GerritUpdatesNotificationComponent implements ProjectComponent, Con
             if (gerritSettings.getAutomaticRefresh() && refreshTimeout > 0) {
                 timer.schedule(new CheckReviewTask(), refreshTimeout * 60 * 1000);
             }
-        }
-    }
-
-    @SuppressWarnings("UnusedDeclaration")
-    private static class Proxy extends GerritUpdatesNotificationComponent {
-
-        private final GerritUpdatesNotificationComponent delegate;
-
-        public Proxy(Project project) {
-            delegate = GerritModule.getInstance(GerritUpdatesNotificationComponent.class);
-            delegate.setProject(project);
-        }
-
-        @Override
-        public void projectOpened() {
-            delegate.projectOpened();
-        }
-
-        @Override
-        public void projectClosed() {
-            delegate.projectClosed();
-        }
-
-        @NotNull
-        @Override
-        public String getComponentName() {
-            return delegate.getComponentName();
-        }
-
-        @Override
-        public void setProject(Project project) {
-            delegate.setProject(project);
         }
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationComponent.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationComponent.java
@@ -47,19 +47,19 @@ public class GerritUpdatesNotificationComponent implements Consumer<List<ChangeI
 
     private Timer timer;
     private Set<String> notifiedChanges = new HashSet<String>();
-    private Project project;
+    private volatile Project project;
 
-    public void projectOpened() {
+    public synchronized void projectOpened() {
         handleNotification();
         setupRefreshTask();
     }
 
-    public void projectClosed() {
+    public synchronized void projectClosed() {
         cancelPendingNotificationTasks();
         notifiedChanges.clear();
     }
 
-    public void handleConfigurationChange() {
+    public synchronized void handleConfigurationChange() {
         cancelPendingNotificationTasks();
         setupRefreshTask();
     }
@@ -111,14 +111,14 @@ public class GerritUpdatesNotificationComponent implements Consumer<List<ChangeI
         }
     }
 
-    private void cancelPendingNotificationTasks() {
+    private synchronized void cancelPendingNotificationTasks() {
         if (timer != null) {
             timer.cancel();
             timer = null;
         }
     }
 
-    private void setupRefreshTask() {
+    private synchronized void setupRefreshTask() {
         long refreshTimeout = gerritSettings.getRefreshTimeout();
         if (gerritSettings.getAutomaticRefresh() && refreshTimeout > 0) {
             if (timer == null) {
@@ -132,15 +132,18 @@ public class GerritUpdatesNotificationComponent implements Consumer<List<ChangeI
         this.project = project;
     }
 
+    /** No-op once the task has been cancelled, so a closed project does not resurrect its timer. */
+    private synchronized void rescheduleRefreshTask() {
+        if (timer != null) {
+            setupRefreshTask();
+        }
+    }
+
     private class CheckReviewTask extends TimerTask {
         @Override
         public void run() {
             handleNotification();
-
-            long refreshTimeout = gerritSettings.getRefreshTimeout();
-            if (gerritSettings.getAutomaticRefresh() && refreshTimeout > 0) {
-                timer.schedule(new CheckReviewTask(), refreshTimeout * 60 * 1000);
-            }
+            rescheduleRefreshTask();
         }
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationStartupActivity.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationStartupActivity.java
@@ -32,8 +32,7 @@ public class GerritUpdatesNotificationStartupActivity implements StartupActivity
     public void runActivity(@NotNull Project project) {
         final GerritUpdatesNotificationComponent component =
                 GerritModule.getInstance(GerritUpdatesNotificationComponent.class);
-        component.setProject(project);
-        component.projectOpened();
+        component.projectOpened(project);
         Disposer.register(project, new Disposable() {
             @Override
             public void dispose() {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationStartupActivity.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationStartupActivity.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2013-2014 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.urswolfer.intellij.plugin.gerrit.ui;
+
+import com.intellij.openapi.Disposable;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.StartupActivity;
+import com.intellij.openapi.util.Disposer;
+import com.urswolfer.intellij.plugin.gerrit.GerritModule;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * @author Urs Wolfer
+ */
+public class GerritUpdatesNotificationStartupActivity implements StartupActivity {
+
+    @Override
+    public void runActivity(@NotNull Project project) {
+        final GerritUpdatesNotificationComponent component =
+                GerritModule.getInstance(GerritUpdatesNotificationComponent.class);
+        component.setProject(project);
+        component.projectOpened();
+        Disposer.register(project, new Disposable() {
+            @Override
+            public void dispose() {
+                component.projectClosed();
+            }
+        });
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 -->
-<idea-plugin>
+<!-- GerritPushExtension modifies git4idea byte-code, which cannot be undone on plugin unload -->
+<idea-plugin require-restart="true">
   <!-- do NOT change the id, see https://intellij-support.jetbrains.com/hc/en-us/community/posts/13362061756050-Plugin-ID-specified-in-plugin-xml-should-not-contain-intellij-   -->
   <id>com.urswolfer.intellij.plugin.gerrit</id>
   <name>Gerrit</name>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -520,20 +520,13 @@
   <depends>com.intellij.modules.lang</depends>
   <depends>Git4Idea</depends>
 
-  <application-components>
-    <component>
-      <implementation-class>com.urswolfer.intellij.plugin.gerrit.push.GerritPushExtension$Proxy</implementation-class>
-    </component>
-  </application-components>
-
-  <project-components>
-    <component>
-      <interface-class>com.intellij.openapi.components.ProjectComponent</interface-class>
-      <implementation-class>com.urswolfer.intellij.plugin.gerrit.ui.GerritUpdatesNotificationComponent$Proxy</implementation-class>
-    </component>
-  </project-components>
+  <applicationListeners>
+    <listener class="com.urswolfer.intellij.plugin.gerrit.push.GerritPushExtensionStarter"
+              topic="com.intellij.ide.AppLifecycleListener"/>
+  </applicationListeners>
 
   <extensions defaultExtensionNs="com.intellij">
+    <postStartupActivity implementation="com.urswolfer.intellij.plugin.gerrit.ui.GerritUpdatesNotificationStartupActivity"/>
     <checkoutProvider implementation="com.urswolfer.intellij.plugin.gerrit.extension.GerritCheckoutProvider$Proxy"/>
     <applicationService serviceInterface="com.urswolfer.intellij.plugin.gerrit.GerritSettings"
                         serviceImplementation="com.urswolfer.intellij.plugin.gerrit.GerritSettings"/>


### PR DESCRIPTION
Clears the 3 `NamedComponent` / `ProjectComponent` deprecations. No baseline change — `AppLifecycleListener` (its `appFrameCreated(List)` is public, not `@ApiStatus.Internal`), `StartupActivity` + the `com.intellij.postStartupActivity` EP, `applicationListeners`, `Disposer` and `require-restart` all exist in 2020.3 and are still non-deprecated in 2026.2.

**Application component → `AppLifecycleListener`.** The registration did nothing but eagerly instantiate `GerritPushExtension$Proxy` at startup, whose constructor asked Guice for `GerritPushExtension`, whose `@Inject initComponent()` runs the javassist rewriting of `GitPushSupport`. `NamedComponent`/`getComponentName()` were vestigial — nothing called them, and `initComponent()` was never invoked by the platform because `NamedComponent` does not declare it. New `GerritPushExtensionStarter` does the same instantiation from `appFrameCreated`, still well before the push dialog is first built.

**Project component → `postStartupActivity` + `Disposable`.** `GerritUpdatesNotificationStartupActivity` does `setProject(project)` then `projectOpened()`, in the same order the old `Proxy` constructor and lifecycle did, and registers a `Disposable` on the project so `projectClosed()` runs on close. `projectOpened()`/`projectClosed()` stay as plain methods; the class keeps its Guice binding and its injections into `GerritSettingsConfigurable` and `RefreshAction` are untouched.

**The plugin stays restart-required.** Dropping the components removes the verifier's restart blocker, but `GerritPushExtension` defines classes into the Git plugin's classloader and rewrites `GitPushSupport` byte-code, neither of which can be undone on unload — so `<idea-plugin require-restart="true">` is now explicit. An earlier revision of this description claimed the plugin becomes dynamically loadable; that was wrong.

**Timer lifecycle hardening.** `ProjectComponent.projectOpened()` was called on the EDT, so project opens were serialized; post-startup activities are not, and the notification component is an application-wide singleton. Two fixes follow from that:

- The lifecycle methods are `synchronized` and `project` is `volatile`. Otherwise two concurrent project opens could each create a `Timer` and orphan one, leaving a non-daemon thread polling forever.
- Each `CheckReviewTask` carries the `Timer` that scheduled it, and reschedules only while that timer is still the current one. A task still inside `handleNotification()` when `handleConfigurationChange()` swapped the timer would otherwise attach a second polling chain to the replacement, once per configuration change.

Both were found by Copilot on this PR; thanks.

Other notes:

- Plain `StartupActivity`, not `StartupActivity.DumbAware`, to stay closest to the old `projectOpened()` threading. On 2024.3+ the platform runs post-startup activities in the background regardless.
- `StartupActivity` is `@ApiStatus.Obsolete` in 2026.2 in favour of `ProjectActivity`, a Kotlin `suspend` interface that does not exist in 2020.3. Obsolete is not one of the categories the verifier reports, so this does not trade one finding for another.
- `GerritPushExtension.initComponent()` keeps its name even though the class is no longer a component; Guice calls it via `@Inject`. Happy to rename it.
- Pre-existing and unchanged: the notification component is an application-wide Guice singleton with a single `project` field, so with several projects open the last one still wins. Making it project-scoped is a wider change than this migration — worth a follow-up.

**This one needs manual verification** — more than the other PRs in this batch. Beyond compiling, the paths to exercise in a real IDE are the Gerrit section of the Git push dialog (proves the startup byte-code injection still lands in time) and the review notifications across project open, settings change and close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Usxh7oZHXBcCr7GVt998bn