### PR TITLE
Replace deprecated AnActionEvent.getRequiredData

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/CheckoutAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/CheckoutAction.java
@@ -23,7 +23,6 @@ import com.google.gerrit.extensions.common.RevisionInfo;
 import com.google.inject.Inject;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
@@ -70,7 +69,10 @@ public class CheckoutAction extends AbstractChangeAction {
         if (!selectedChange.isPresent()) {
             return;
         }
-        final Project project = anActionEvent.getRequiredData(PlatformDataKeys.PROJECT);
+        final Project project = anActionEvent.getProject();
+        if (project == null) {
+            return;
+        }
 
         getChangeDetail(selectedChange.get(), project, new Consumer<ChangeInfo>() {
             @Override


### PR DESCRIPTION
1 scheduled-for-removal usage, in `CheckoutAction`. No baseline change — `AnActionEvent.getProject()` has always been there.

`getRequiredData` is deprecated in favour of `getData`; `getProject()` is the standard accessor for this key. Since it is nullable where `getRequiredData` asserted, the action now bails out on `null`, next to the existing early return for "no change selected".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Usxh7oZHXBcCr7GVt998bn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Usxh7oZHXBcCr7GVt998bn)_