### PR TITLE
Call getChanges through VcsFullCommitDetails

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/changesbrowser/ChangesWithCommitMessageProvider.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/changesbrowser/ChangesWithCommitMessageProvider.java
@@ -22,6 +22,7 @@ import com.intellij.openapi.vcs.FilePath;
 import com.intellij.openapi.vcs.RemoteFilePath;
 import com.intellij.openapi.vcs.changes.Change;
 import com.intellij.openapi.vcs.changes.SimpleContentRevision;
+import com.intellij.vcs.log.VcsFullCommitDetails;
 import git4idea.GitCommit;
 import org.jetbrains.annotations.NotNull;
 
@@ -38,7 +39,9 @@ public class ChangesWithCommitMessageProvider implements CommitDiffBuilder.Chang
     }
 
     private Collection<Change> getChangesWithCommitMessage(GitCommit gitCommit) {
-        Collection<Change> changes = gitCommit.getChanges();
+        // through the published interface: VcsChangesLazilyParsedDetails is experimental API
+        VcsFullCommitDetails commitDetails = gitCommit;
+        Collection<Change> changes = commitDetails.getChanges();
 
         String content = new CommitMessageFormatter(gitCommit).getLongCommitMessage();
         FilePath commitMsg = new RemoteFilePath("/COMMIT_MSG", false) {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/changesbrowser/CommitDiffBuilder.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/changesbrowser/CommitDiffBuilder.java
@@ -25,6 +25,7 @@ import com.intellij.openapi.vcs.VcsException;
 import com.intellij.openapi.vcs.changes.Change;
 import com.intellij.openapi.vcs.changes.ContentRevision;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.vcs.log.VcsFullCommitDetails;
 import com.urswolfer.intellij.plugin.gerrit.util.PathUtils;
 import git4idea.GitCommit;
 import git4idea.changes.GitChangeUtils;
@@ -95,7 +96,9 @@ public class CommitDiffBuilder {
     private static final class SimpleChangesProvider implements ChangesProvider {
         @Override
         public Collection<Change> provide(GitCommit gitCommit) {
-            return gitCommit.getChanges();
+            // through the published interface: VcsChangesLazilyParsedDetails is experimental API
+            VcsFullCommitDetails commitDetails = gitCommit;
+            return commitDetails.getChanges();
         }
     }
 }


### PR DESCRIPTION
Both experimental API usages in the report, in `CommitDiffBuilder` and `ChangesWithCommitMessageProvider`. No baseline change.

`GitCommit` inherits `getChanges()` from `VcsChangesLazilyParsedDetails`, which is `@ApiStatus.Experimental` — so the compiler records the experimental class as the call's owner. `VcsFullCommitDetails` (`vcs-log/api`) declares the same method and carries no annotation, in 2020.3 and in 2026.2 alike, so calling through it clears the finding and is the better dependency anyway.

Done with a local of the interface type rather than changing `ChangesProvider.provide(GitCommit)`: the providers also use `GitCommit` for `getId()` and `CommitMessageFormatter`, so widening the interface would have rippled through `CommitDiffBuilder`'s fields and constructor for no gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Usxh7oZHXBcCr7GVt998bn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Usxh7oZHXBcCr7GVt998bn)_