### PR TITLE
Replace deprecated Notification.setListener with an action

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/GerritUtil.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/GerritUtil.java
@@ -40,8 +40,7 @@ import com.google.gerrit.extensions.common.RevisionInfo;
 import com.google.gerrit.extensions.restapi.RestApiException;
 import com.google.gerrit.extensions.restapi.Url;
 import com.google.inject.Inject;
-import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationListener;
+import com.intellij.notification.NotificationAction;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.options.ShowSettingsUtil;
@@ -71,7 +70,6 @@ import git4idea.repo.GitRemote;
 import git4idea.repo.GitRepository;
 import org.jetbrains.annotations.NotNull;
 
-import javax.swing.event.HyperlinkEvent;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -434,16 +432,14 @@ public class GerritUtil {
 
     public void showAddGitRepositoryNotification(final Project project) {
         NotificationBuilder notification = new NotificationBuilder(project, "Insufficient dependencies for Gerrit plugin",
-                "Please configure a Git repository.<br/><a href='vcs'>Open Settings</a>")
-                .listener(new NotificationListener() {
+                "Please configure a Git repository.")
+                .action(NotificationAction.createSimpleExpiring("Open Settings", new Runnable() {
                     @Override
-                    public void hyperlinkUpdate(@NotNull Notification notification, @NotNull HyperlinkEvent event) {
-                        if (event.getEventType() == HyperlinkEvent.EventType.ACTIVATED && event.getDescription().equals("vcs")) {
-                            ShowSettingsUtil.getInstance().showSettingsDialog(project,
-                                    VcsBundle.message("version.control.main.configurable.name"));
-                        }
+                    public void run() {
+                        ShowSettingsUtil.getInstance().showSettingsDialog(project,
+                                VcsBundle.message("version.control.main.configurable.name"));
                     }
-                });
+                }));
         notificationService.notifyWarning(notification);
     }
 

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/NotificationBuilder.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/NotificationBuilder.java
@@ -16,11 +16,13 @@
 
 package com.urswolfer.intellij.plugin.gerrit.util;
 
-import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
 import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationListener;
 import com.intellij.notification.NotificationType;
+import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.project.Project;
+
+import java.util.List;
 
 /**
  * @author Thomas Forrer
@@ -33,7 +35,7 @@ public final class NotificationBuilder {
     private final String message;
     private NotificationType type = NotificationType.INFORMATION;
 
-    private Optional<NotificationListener> listener = Optional.absent();
+    private final List<AnAction> actions = Lists.newArrayList();
     private boolean showBalloon = true;
 
     public NotificationBuilder(Project project, String title, String message) {
@@ -42,8 +44,8 @@ public final class NotificationBuilder {
         this.message = message;
     }
 
-    public NotificationBuilder listener(NotificationListener listener) {
-        this.listener = Optional.of(listener);
+    public NotificationBuilder action(AnAction action) {
+        actions.add(action);
         return this;
     }
 
@@ -64,8 +66,8 @@ public final class NotificationBuilder {
 
     protected Notification get() {
         Notification notification = new Notification(GERRIT_NOTIFICATION_GROUP, title, message, type);
-        if (listener.isPresent()) {
-            notification.setListener(listener.get());
+        for (AnAction action : actions) {
+            notification.addAction(action);
         }
         if (!showBalloon) {
             notification.expire();


### PR DESCRIPTION
1 deprecated usage, in `NotificationBuilder.get()`. No baseline change — `Notification.addAction` and `NotificationAction` both exist in 2020.3.

`setListener` is deprecated in favour of `addAction`, which is the modern notification idiom: a button instead of an HTML link handled by a `NotificationListener`. `NotificationBuilder.listener(NotificationListener)` becomes `action(AnAction)` and collects actions; the one caller, the "Insufficient dependencies" warning, drops `<a href='vcs'>Open Settings</a>` from its message in favour of a real action.

**Two visible changes**, both intended but worth checking:

- "Open Settings" is now a notification action button, not a link inside the text.
- It uses `NotificationAction.createSimpleExpiring`, so the balloon dismisses itself once settings open. The old link left the warning standing. Say the word and I'll switch to `createSimple` to keep the previous behaviour.

`NotificationBuilder.action(...)` takes `AnAction` rather than `NotificationAction` so callers can pass either; `addAction` accepts `AnAction`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Usxh7oZHXBcCr7GVt998bn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Usxh7oZHXBcCr7GVt998bn)_