### PR TITLE
Make GerritUpdatesNotificationComponent per-project

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritSettingsConfigurable.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritSettingsConfigurable.java
@@ -45,8 +45,6 @@ public class GerritSettingsConfigurable implements SearchableConfigurable, VcsCo
 
     @Inject
     private GerritSettings gerritSettings;
-    @Inject
-    private GerritUpdatesNotificationComponent gerritUpdatesNotificationComponent;
 
     @NotNull
     public String getDisplayName() {
@@ -104,7 +102,7 @@ public class GerritSettingsConfigurable implements SearchableConfigurable, VcsCo
             gerritSettings.setShowProjectColumn(settingsPane.getShowProjectColumn());
             gerritSettings.setCloneBaseUrl(settingsPane.getCloneBaseUrl());
 
-            gerritUpdatesNotificationComponent.handleConfigurationChange();
+            GerritUpdatesNotificationComponent.configurationChanged();
         }
     }
 

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUiModule.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUiModule.java
@@ -33,7 +33,6 @@ public class GerritUiModule extends AbstractModule {
         bind(RepositoryChangesBrowserProvider.class);
         bind(SettingsPanel.class);
         bind(GerritSettingsConfigurable.class);
-        bind(GerritUpdatesNotificationComponent.class).asEagerSingleton();
         bind(GerritChangeListPanel.class);
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationComponent.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationComponent.java
@@ -71,7 +71,7 @@ public final class GerritUpdatesNotificationComponent implements Consumer<List<C
 
     public synchronized void projectOpened() {
         handleNotification();
-        setupRefreshTask();
+        restartRefreshTask();
     }
 
     @Override
@@ -81,8 +81,7 @@ public final class GerritUpdatesNotificationComponent implements Consumer<List<C
     }
 
     public synchronized void handleConfigurationChange() {
-        cancelPendingNotificationTasks();
-        setupRefreshTask();
+        restartRefreshTask();
     }
 
     public void handleNotification() {
@@ -141,6 +140,12 @@ public final class GerritUpdatesNotificationComponent implements Consumer<List<C
             timer.cancel();
             timer = null;
         }
+    }
+
+    /** Both entry points go through here, so an already running task is never left behind next to a new one. */
+    private synchronized void restartRefreshTask() {
+        cancelPendingNotificationTasks();
+        setupRefreshTask();
     }
 
     private synchronized void setupRefreshTask() {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationComponent.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationComponent.java
@@ -18,14 +18,17 @@ package com.urswolfer.intellij.plugin.gerrit.ui;
 
 import com.google.common.base.Strings;
 import com.google.gerrit.extensions.common.ChangeInfo;
-import com.google.inject.Inject;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import com.intellij.util.Consumer;
+import com.urswolfer.intellij.plugin.gerrit.GerritModule;
 import com.urswolfer.intellij.plugin.gerrit.GerritSettings;
 import com.urswolfer.intellij.plugin.gerrit.rest.GerritUtil;
 import com.urswolfer.intellij.plugin.gerrit.util.NotificationBuilder;
 import com.urswolfer.intellij.plugin.gerrit.util.NotificationService;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -33,29 +36,46 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 /**
- * Driven by {@link GerritUpdatesNotificationStartupActivity}.
+ * Project service, started by {@link GerritUpdatesNotificationStartupActivity} and disposed with its project.
  *
  * @author Urs Wolfer
  */
-public class GerritUpdatesNotificationComponent implements Consumer<List<ChangeInfo>> {
-    @Inject
-    private GerritUtil gerritUtil;
-    @Inject
-    private GerritSettings gerritSettings;
-    @Inject
-    private NotificationService notificationService;
+public final class GerritUpdatesNotificationComponent implements Consumer<List<ChangeInfo>>, Disposable {
+    private final Project project;
+    private final GerritUtil gerritUtil;
+    private final GerritSettings gerritSettings;
+    private final NotificationService notificationService;
 
+    private final Set<String> notifiedChanges = Collections.synchronizedSet(new HashSet<String>());
     private Timer timer;
-    private Set<String> notifiedChanges = new HashSet<String>();
-    private volatile Project project;
 
-    public synchronized void projectOpened(Project project) {
+    public GerritUpdatesNotificationComponent(Project project) {
         this.project = project;
+        gerritUtil = GerritModule.getInstance(GerritUtil.class);
+        gerritSettings = GerritModule.getInstance(GerritSettings.class);
+        notificationService = GerritModule.getInstance(NotificationService.class);
+    }
+
+    public static GerritUpdatesNotificationComponent getInstance(Project project) {
+        return project.getService(GerritUpdatesNotificationComponent.class);
+    }
+
+    /** The settings are application wide, so every open project has to pick up a change. */
+    public static void configurationChanged() {
+        for (Project project : ProjectManager.getInstance().getOpenProjects()) {
+            if (!project.isDisposed()) {
+                getInstance(project).handleConfigurationChange();
+            }
+        }
+    }
+
+    public synchronized void projectOpened() {
         handleNotification();
         setupRefreshTask();
     }
 
-    public synchronized void projectClosed() {
+    @Override
+    public void dispose() {
         cancelPendingNotificationTasks();
         notifiedChanges.clear();
     }
@@ -66,6 +86,10 @@ public class GerritUpdatesNotificationComponent implements Consumer<List<ChangeI
     }
 
     public void handleNotification() {
+        if (project.isDisposed()) {
+            return;
+        }
+
         if (!gerritSettings.getReviewNotifications()) {
             return;
         }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationStartupActivity.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationStartupActivity.java
@@ -16,11 +16,8 @@
 
 package com.urswolfer.intellij.plugin.gerrit.ui;
 
-import com.intellij.openapi.Disposable;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupActivity;
-import com.intellij.openapi.util.Disposer;
-import com.urswolfer.intellij.plugin.gerrit.GerritModule;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -30,14 +27,6 @@ public class GerritUpdatesNotificationStartupActivity implements StartupActivity
 
     @Override
     public void runActivity(@NotNull Project project) {
-        final GerritUpdatesNotificationComponent component =
-                GerritModule.getInstance(GerritUpdatesNotificationComponent.class);
-        component.projectOpened(project);
-        Disposer.register(project, new Disposable() {
-            @Override
-            public void dispose() {
-                component.projectClosed();
-            }
-        });
+        GerritUpdatesNotificationComponent.getInstance(project).projectOpened();
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/RefreshAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/RefreshAction.java
@@ -16,7 +16,6 @@
 
 package com.urswolfer.intellij.plugin.gerrit.ui.action;
 
-import com.google.inject.Inject;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -34,9 +33,6 @@ import com.urswolfer.intellij.plugin.gerrit.ui.GerritUpdatesNotificationComponen
  */
 @SuppressWarnings("ComponentNotRegistered") // proxy class below is registered
 public class RefreshAction extends AnAction implements DumbAware, UpdateInBackground {
-    @Inject
-    private GerritUpdatesNotificationComponent gerritUpdatesNotificationComponent;
-
     public RefreshAction() {
         super("Refresh", "Refresh changes list", AllIcons.Actions.Refresh);
     }
@@ -47,7 +43,7 @@ public class RefreshAction extends AnAction implements DumbAware, UpdateInBackgr
         GerritToolWindowFactory.ProjectService projectService = project.getService(GerritToolWindowFactory.ProjectService.class);
         GerritToolWindow gerritToolWindow = projectService.getGerritToolWindow();
         gerritToolWindow.reloadChanges(project, true);
-        gerritUpdatesNotificationComponent.handleNotification();
+        GerritUpdatesNotificationComponent.getInstance(project).handleNotification();
     }
 
     public static class Proxy extends RefreshAction {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -535,6 +535,7 @@
 
     <toolWindow id="Gerrit" icon="MyIcons.Gerrit" anchor="bottom"
                 factoryClass="com.urswolfer.intellij.plugin.gerrit.ui.GerritToolWindowFactory"/>
+    <projectService serviceImplementation="com.urswolfer.intellij.plugin.gerrit.ui.GerritUpdatesNotificationComponent"/>
     <projectService serviceInterface="com.urswolfer.intellij.plugin.gerrit.ui.GerritToolWindowFactory$ProjectService"
                     serviceImplementation="com.urswolfer.intellij.plugin.gerrit.ui.GerritToolWindowFactory$ProjectService" />
     <diff.DiffTool implementation="com.urswolfer.intellij.plugin.gerrit.ui.diff.CommentsDiffTool$Proxy"/>


### PR DESCRIPTION
The follow-up from #561. That PR kept the application-wide Guice singleton alive with locks; this removes the shared state instead. No baseline change — `projectService`, `project.getService()`, `Disposable` services and `ProjectManager.getOpenProjects()` all exist in 2020.3.

It is now a project service, registered in `plugin.xml` the same way `GerritToolWindowFactory$ProjectService` already is. What that fixes:

- **`project` is final**, set by the constructor the platform calls. The atomicity problem behind #561's last review round cannot occur — there is no assignment to interleave, so `setProject` and the `synchronized projectOpened(Project)` are both gone.
- **One timer per project.** Previously the second `projectOpened` scheduled another `CheckReviewTask` on the shared timer, so two open projects polled twice per interval and a close on either killed both. This is the doubling I flagged but declined to fix in #561, since fixing it there meant changing behaviour rather than the structure.
- **`notifiedChanges` is per project**, so one project's changes no longer suppress another's "NEW" markers. It is also a synchronized set now — `handleNotification()` can be triggered from the timer thread and the toolbar at once, and the callbacks mutated a plain `HashSet`.
- **Disposal is the platform's.** The service implements `Disposable`, and `ComponentManagerImpl` registers `Disposable` services against the project's service disposable in 2020.3 and 2026.2 alike, so the manual `Disposer.register(project, …)` in the startup activity was redundant and is gone. `projectClosed()` became `dispose()`.

Call sites:

- `GerritUpdatesNotificationStartupActivity` is now one line: `getInstance(project).projectOpened()`.
- `RefreshAction` takes the component from the project it acts on, next to the `ProjectService` lookup it already does, instead of holding an injected singleton.
- `GerritSettingsConfigurable` calls the new static `configurationChanged()`, which walks `getOpenProjects()`. `GerritSettings` is an `applicationService`, so a settings change has to reach every open project; this also means enabling notifications now starts polling in all of them rather than only the last-opened one.
- The Guice binding is dropped; the collaborators (`GerritUtil`, `GerritSettings`, `NotificationService`) are pulled from the injector once in the constructor, as the `Proxy` classes elsewhere in this plugin do.

`handleNotification()` also returns early when the project is disposed — with a background poller per project that guard is worth having, and the timer can outlive a close by one in-flight task.

The `synchronized` on the timer methods stays: `handleConfigurationChange()` on the EDT and `rescheduleRefreshTask()` on the timer thread still race within a single project, and the timer-identity check from #561 still guards a config change replacing the timer under a running task.

Worth exercising in a real IDE, ideally with **two projects open**: notifications on open, a settings change reaching both, refresh from the toolbar, and closing one project leaving the other polling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Usxh7oZHXBcCr7GVt998bn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Usxh7oZHXBcCr7GVt998bn)_