### PR TITLE
Get IDE singletons from their own getInstance()

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/OpenIdeDependenciesModule.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/OpenIdeDependenciesModule.java
@@ -17,21 +17,13 @@
 package com.urswolfer.intellij.plugin.gerrit;
 
 import com.google.inject.AbstractModule;
-import com.intellij.ide.DataManager;
-import com.intellij.openapi.application.Application;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.options.ShowSettingsUtil;
-import com.intellij.openapi.ui.popup.JBPopupFactory;
-import com.intellij.openapi.vfs.LocalFileSystem;
-import com.intellij.openapi.vfs.VirtualFileManager;
-import git4idea.commands.Git;
 
 /**
- * Bindings for all dependencies to required OpenIDE service instances.
+ * Bindings for OpenIDE instances that cannot be reached through a static accessor.
  *
- * If you want to avoid calls to #getInstance() register the required
- * idea service here and inject it in your own service.
+ * IDE services and components expose a #getInstance() of their own; call that where you need one instead of
+ * routing it through this module.
  *
  * @author Thomas Forrer
  */
@@ -41,16 +33,5 @@ public class OpenIdeDependenciesModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(Logger.class).toInstance(LOG);
-        bind(Application.class).toInstance(ApplicationManager.getApplication());
-
-        bind(LocalFileSystem.class).toInstance(LocalFileSystem.getInstance());
-
-        bind(Git.class).toInstance(ApplicationManager.getApplication().getService(Git.class));
-        bind(VirtualFileManager.class).toInstance(VirtualFileManager.getInstance());
-
-        bind(ShowSettingsUtil.class).toInstance(ShowSettingsUtil.getInstance());
-        bind(DataManager.class).toInstance(DataManager.getInstance());
-
-        bind(JBPopupFactory.class).toInstance(JBPopupFactory.getInstance());
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/extension/GerritCheckoutProvider.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/extension/GerritCheckoutProvider.java
@@ -72,8 +72,6 @@ public class GerritCheckoutProvider implements CheckoutProvider {
     private static final Ordering<ProjectInfo> ID_REVERSE_ORDERING = Ordering.natural().onResultOf(GET_ID_FUNCTION).reverse();
 
     @Inject
-    private LocalFileSystem localFileSystem;
-    @Inject
     private GerritUtil gerritUtil;
     @Inject
     private GerritSettings gerritSettings;
@@ -118,7 +116,7 @@ public class GerritCheckoutProvider implements CheckoutProvider {
             return;
         }
         dialog.rememberSettings();
-        final VirtualFile destinationParent = localFileSystem.findFileByIoFile(new File(dialog.getParentDirectory()));
+        final VirtualFile destinationParent = LocalFileSystem.getInstance().findFileByIoFile(new File(dialog.getParentDirectory()));
         if (destinationParent == null) {
             return;
         }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/git/GerritGitUtil.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/git/GerritGitUtil.java
@@ -25,7 +25,7 @@ import com.google.gerrit.extensions.common.ChangeInfo;
 import com.google.gerrit.extensions.common.FetchInfo;
 import com.google.inject.Inject;
 import com.intellij.dvcs.util.CommitCompareInfo;
-import com.intellij.openapi.application.Application;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.Task;
@@ -82,12 +82,6 @@ import java.util.concurrent.Callable;
  * @author Urs Wolfer
  */
 public class GerritGitUtil {
-    @Inject
-    private Git git;
-    @Inject
-    private Application application;
-    @Inject
-    private VirtualFileManager virtualFileManager;
     @Inject
     private GerritSettings gerritSettings;
     @Inject
@@ -224,11 +218,11 @@ public class GerritGitUtil {
                     VcsShortCommitDetails gitCommit = new VcsShortCommitDetailsImpl(
                         HashImpl.build(revisionId), Collections.<Hash>emptyList(), 0, virtualFile, notLoaded, notLoadedUser, notLoadedUser, 0);
 
-                    cherryPick(gitRepository, gitCommit, git, project);
+                    cherryPick(gitRepository, gitCommit, project);
                 } finally {
-                    application.invokeLater(new Runnable() {
+                    ApplicationManager.getApplication().invokeLater(new Runnable() {
                         public void run() {
-                            virtualFileManager.syncRefresh();
+                            VirtualFileManager.getInstance().syncRefresh();
                             ChangeListManagerEx.getInstanceEx(project).unblockModalNotifications();
                         }
                     });
@@ -241,12 +235,12 @@ public class GerritGitUtil {
      * A lot of this code is based on: git4idea.cherrypick.GitCherryPicker#cherryPick() (which is private)
      */
     private boolean cherryPick(@NotNull GitRepository repository, @NotNull VcsShortCommitDetails commit,
-                               @NotNull Git git, @NotNull Project project) {
+                               @NotNull Project project) {
         GitSimpleEventDetector conflictDetector = new GitSimpleEventDetector(CHERRY_PICK_CONFLICT);
         GitSimpleEventDetector localChangesOverwrittenDetector = new GitSimpleEventDetector(LOCAL_CHANGES_OVERWRITTEN_BY_CHERRY_PICK);
         GitUntrackedFilesOverwrittenByOperationDetector untrackedFilesDetector =
                 new GitUntrackedFilesOverwrittenByOperationDetector(repository.getRoot());
-        GitCommandResult result = git.cherryPick(repository, commit.getId().asString(), false, true,
+        GitCommandResult result = Git.getInstance().cherryPick(repository, commit.getId().asString(), false, true,
                 conflictDetector, localChangesOverwrittenDetector, untrackedFilesDetector);
         if (result.success()) {
             return true;
@@ -339,7 +333,7 @@ public class GerritGitUtil {
         h.addParameters("--format=short");
         h.endOptions();
         h.addLineListener(listener);
-        GitCommandResult gitCommandResult = git.runCommand(new Computable<GitLineHandler>() {
+        GitCommandResult gitCommandResult = Git.getInstance().runCommand(new Computable<GitLineHandler>() {
             @Override
             public GitLineHandler compute() {
                 return h;
@@ -383,7 +377,7 @@ public class GerritGitUtil {
         h.addParameters("-u", "remotes/" + remoteBranch);
         h.endOptions();
         h.addLineListener(listener);
-        GitCommandResult gitCommandResult = git.runCommand(new Computable<GitLineHandler>() {
+        GitCommandResult gitCommandResult = Git.getInstance().runCommand(new Computable<GitLineHandler>() {
             @Override
             public GitLineHandler compute() {
                 return h;

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritChangeListPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritChangeListPanel.java
@@ -78,7 +78,6 @@ public class GerritChangeListPanel extends JPanel implements Consumer<LoadChange
     private final SelectedRevisions selectedRevisions;
     private final GerritSelectRevisionInfoColumn selectRevisionInfoColumn;
     private final GerritSettings gerritSettings;
-    private final ShowSettingsUtil showSettingsUtil;
 
     private final List<ChangeInfo> changes;
     private final TableView<ChangeInfo> table;
@@ -92,12 +91,10 @@ public class GerritChangeListPanel extends JPanel implements Consumer<LoadChange
     @Inject
     public GerritChangeListPanel(SelectedRevisions selectedRevisions,
                                  GerritSelectRevisionInfoColumn selectRevisionInfoColumn,
-                                 GerritSettings gerritSettings,
-                                 ShowSettingsUtil showSettingsUtil) {
+                                 GerritSettings gerritSettings) {
         this.selectedRevisions = selectedRevisions;
         this.selectRevisionInfoColumn = selectRevisionInfoColumn;
         this.gerritSettings = gerritSettings;
-        this.showSettingsUtil = showSettingsUtil;
         this.changes = Lists.newArrayList();
 
         this.table = new TableView<ChangeInfo>();
@@ -174,7 +171,7 @@ public class GerritChangeListPanel extends JPanel implements Consumer<LoadChange
             emptyText.appendText("settings", SimpleTextAttributes.LINK_ATTRIBUTES, new ActionListener() {
                 @Override
                 public void actionPerformed(ActionEvent actionEvent) {
-                    showSettingsUtil.showSettingsDialog(project, GerritSettingsConfigurable.NAME);
+                    ShowSettingsUtil.getInstance().showSettingsDialog(project, GerritSettingsConfigurable.NAME);
                 }
             });
             emptyText.appendText(" to configure this plugin and press the refresh button afterwards.");

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/SettingsAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/SettingsAction.java
@@ -16,7 +16,6 @@
 
 package com.urswolfer.intellij.plugin.gerrit.ui.action;
 
-import com.google.inject.Inject;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -34,8 +33,6 @@ import com.urswolfer.intellij.plugin.gerrit.ui.GerritSettingsConfigurable;
 @SuppressWarnings("ComponentNotRegistered") // proxy class below is registered
 public class SettingsAction extends AnAction implements DumbAware, UpdateInBackground {
 
-    @Inject
-    private ShowSettingsUtil showSettingsUtil;
 
     public SettingsAction() {
         super("Settings", "Open Gerrit Plugin Settings", AllIcons.General.Settings);
@@ -44,7 +41,7 @@ public class SettingsAction extends AnAction implements DumbAware, UpdateInBackg
     @Override
     public void actionPerformed(AnActionEvent anActionEvent) {
         final Project project = anActionEvent.getData(PlatformDataKeys.PROJECT);
-        showSettingsUtil.showSettingsDialog(project, GerritSettingsConfigurable.NAME);
+        ShowSettingsUtil.getInstance().showSettingsDialog(project, GerritSettingsConfigurable.NAME);
     }
 
     public static class Proxy extends SettingsAction {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/CommentBalloonBuilder.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/CommentBalloonBuilder.java
@@ -16,7 +16,6 @@
 
 package com.urswolfer.intellij.plugin.gerrit.ui.diff;
 
-import com.google.inject.Inject;
 import com.intellij.openapi.actionSystem.CommonShortcuts;
 import com.intellij.openapi.keymap.KeymapUtil;
 import com.intellij.openapi.ui.popup.ComponentPopupBuilder;
@@ -35,11 +34,9 @@ public class CommentBalloonBuilder {
         String.format("Hit %s to create a comment. It will be published once you post your review.",
             KeymapUtil.getShortcutsText(CommonShortcuts.CTRL_ENTER.getShortcuts()));
 
-    @Inject
-    private JBPopupFactory jbPopupFactory;
 
     public JBPopup getNewCommentBalloon(final CommentForm balloonContent, @NotNull final String title) {
-        final ComponentPopupBuilder builder = jbPopupFactory.
+        final ComponentPopupBuilder builder = JBPopupFactory.getInstance().
                 createComponentPopupBuilder(balloonContent, balloonContent);
         builder.setAdText(POPUP_TEXT);
         builder.setTitle(title);

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/AbstractUserFilter.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/AbstractUserFilter.java
@@ -18,7 +18,6 @@ package com.urswolfer.intellij.plugin.gerrit.ui.filter;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
-import com.google.inject.Inject;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.CommonShortcuts;
@@ -45,8 +44,6 @@ public abstract class AbstractUserFilter extends AbstractChangesFilter {
     private static final String POPUP_TEXT = String.format("%s to search",
         KeymapUtil.getShortcutsText(CommonShortcuts.CTRL_ENTER.getShortcuts()));
 
-    @Inject
-    private JBPopupFactory jbPopupFactory;
 
     private ImmutableList<User> users;
     private JBPopup popup;
@@ -152,7 +149,7 @@ public abstract class AbstractUserFilter extends AbstractChangesFilter {
         }
 
         private JBPopup buildBalloon(JTextArea textArea) {
-            ComponentPopupBuilder builder = jbPopupFactory.
+            ComponentPopupBuilder builder = JBPopupFactory.getInstance().
                 createComponentPopupBuilder(textArea, textArea);
             builder.setAdText(POPUP_TEXT);
             builder.setResizable(true);


### PR DESCRIPTION
`OpenIdeDependenciesModule` bound `Application`, `LocalFileSystem`, `Git`, `VirtualFileManager`, `ShowSettingsUtil`, `DataManager` and `JBPopupFactory` to exactly the values their own static accessors return:

```java
bind(ShowSettingsUtil.class).toInstance(ShowSettingsUtil.getInstance());
```

Injecting them bought nothing over calling those accessors, and put IDE state into the object graph. This calls the accessors directly and drops the bindings.

The `DataManager` binding already had no injection point at all — both of its users call `DataManager.getInstance()` today, which is the shape this change adopts everywhere else.

Two signatures existed only to hand an injected instance around and lose the parameter here:

- the private `GerritGitUtil#cherryPick` took the `Git` it now looks up itself;
- `GerritChangeListPanel`'s constructor took a `ShowSettingsUtil` used in exactly one place.

### Scope

The module keeps its `Logger` binding, so this is independent of #569 — the two only meet in eventually emptying the same file, and either can merge first. Nothing else about the Guice setup is touched.