### PR TITLE
Replace deprecated ContentFactory.SERVICE

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritToolWindowFactory.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritToolWindowFactory.java
@@ -22,7 +22,6 @@ import com.intellij.openapi.ui.SimpleToolWindowPanel;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowFactory;
 import com.intellij.ui.content.Content;
-import com.intellij.ui.content.ContentFactory;
 import com.intellij.ui.content.ContentManager;
 import com.urswolfer.intellij.plugin.gerrit.GerritModule;
 
@@ -40,7 +39,7 @@ public class GerritToolWindowFactory implements ToolWindowFactory, DumbAware {
         SimpleToolWindowPanel toolWindowContent = gerritToolWindow.createToolWindowContent(project);
 
         ContentManager contentManager = toolWindow.getContentManager();
-        Content content = ContentFactory.SERVICE.getInstance().createContent(toolWindowContent, "", false);
+        Content content = contentManager.getFactory().createContent(toolWindowContent, "", false);
         contentManager.addContent(content);
         contentManager.setSelectedContent(content);
     }


### PR DESCRIPTION
1 scheduled-for-removal usage, in `GerritToolWindowFactory`. No baseline change.

The obvious replacement, the static `ContentFactory.getInstance()`, only exists from 2022.3 — in 2020.3 the class has nothing but the `SERVICE` holder. `ContentManager.getFactory()` is the way that works on both: present and non-deprecated in 2020.3 and in 2026.2, and in 2026.2 `ContentManager.addContent` even points at it. The content manager is already a local in this method, and taking the factory from the manager the content is added to is arguably more correct than reaching for the application-level one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Usxh7oZHXBcCr7GVt998bn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Usxh7oZHXBcCr7GVt998bn)_