### PR TITLE
Replace deprecated VcsUserImpl constructor

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/git/GerritGitUtil.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/git/GerritGitUtil.java
@@ -43,9 +43,9 @@ import com.intellij.openapi.vfs.VirtualFileManager;
 import com.intellij.vcs.log.Hash;
 import com.intellij.vcs.log.VcsShortCommitDetails;
 import com.intellij.vcs.log.VcsUser;
+import com.intellij.vcs.log.VcsUserRegistry;
 import com.intellij.vcs.log.impl.HashImpl;
 import com.intellij.vcs.log.impl.VcsShortCommitDetailsImpl;
-import com.intellij.vcs.log.impl.VcsUserImpl;
 import com.urswolfer.intellij.plugin.gerrit.GerritSettings;
 import com.urswolfer.intellij.plugin.gerrit.util.NotificationBuilder;
 import com.urswolfer.intellij.plugin.gerrit.util.NotificationService;
@@ -214,7 +214,7 @@ public class GerritGitUtil {
                     final VirtualFile virtualFile = gitRepository.getRoot();
 
                     final String notLoaded = "Not loaded";
-                    VcsUser notLoadedUser = new VcsUserImpl(notLoaded, notLoaded);
+                    VcsUser notLoadedUser = project.getService(VcsUserRegistry.class).createUser(notLoaded, notLoaded);
                     VcsShortCommitDetails gitCommit = new VcsShortCommitDetailsImpl(
                         HashImpl.build(revisionId), Collections.<Hash>emptyList(), 0, virtualFile, notLoaded, notLoadedUser, notLoadedUser, 0);
 


### PR DESCRIPTION
1 deprecated usage, in `GerritGitUtil.cherryPickChange`. No baseline change.

The constructor's deprecation says "Use VcsUserUtil.createUser", and that helper only appears in 2026.2 — but the same thing has been reachable all along through `VcsUserRegistry.createUser(name, email)`, which is present and non-deprecated in 2020.3 and 2026.2 alike. `VcsUserRegistry` is registered as a `projectService` in both versions, so `project.getService(...)` is the right lookup; `project` is already in scope in the background task.

This is the placeholder `"Not loaded"` user handed to `VcsShortCommitDetailsImpl` for the cherry-pick, so behaviour is unchanged apart from the registry interning the instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Usxh7oZHXBcCr7GVt998bn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Usxh7oZHXBcCr7GVt998bn)_