### PR TITLE
Bound the tool window's listeners to its lifetime

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/SelectedRevisions.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/SelectedRevisions.java
@@ -20,6 +20,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.gerrit.extensions.common.ChangeInfo;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
 import com.intellij.util.EventDispatcher;
@@ -43,8 +44,12 @@ public final class SelectedRevisions {
         return ApplicationManager.getApplication().getService(SelectedRevisions.class);
     }
 
-    public void addListener(Listener listener) {
-        eventDispatcher.addListener(listener);
+    /**
+     * @param parent disposed when the listener goes out of scope; this service outlives every listener it has, so
+     *               registering without one keeps the listener, and everything it holds, alive for the IDE session
+     */
+    public void addListener(Listener listener, Disposable parent) {
+        eventDispatcher.addListener(listener, parent);
     }
 
     /**

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritCommentCountChangeNodeDecorator.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritCommentCountChangeNodeDecorator.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Lists;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.google.gerrit.extensions.common.CommentInfo;
 import com.google.gerrit.extensions.restapi.RestApiException;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vcs.changes.Change;
@@ -55,7 +56,7 @@ public class GerritCommentCountChangeNodeDecorator implements GerritChangeNodeDe
     private Supplier<Map<String, List<CommentInfo>>> drafts = setupDraftsSupplier();
     private Supplier<Set<String>> reviewed = setupReviewedSupplier();
 
-    public GerritCommentCountChangeNodeDecorator() {
+    public GerritCommentCountChangeNodeDecorator(Disposable parent) {
         this.selectedRevisions = SelectedRevisions.getInstance();
         this.selectedRevisions.addListener(new SelectedRevisions.Listener() {
             @Override
@@ -64,7 +65,7 @@ public class GerritCommentCountChangeNodeDecorator implements GerritChangeNodeDe
                     refreshSuppliers();
                 }
             }
-        });
+        }, parent);
     }
 
     private void refreshSuppliers() {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritToolWindow.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritToolWindow.java
@@ -21,6 +21,7 @@ import com.google.common.base.Strings;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.intellij.dvcs.repo.VcsRepositoryManager;
 import com.intellij.dvcs.repo.VcsRepositoryMappingListener;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.ActionToolbar;
 import com.intellij.openapi.actionSystem.Constraints;
@@ -48,7 +49,7 @@ import java.util.List;
  * @author Urs Wolfer
  * @author Konrad Dobrzynski
  */
-public class GerritToolWindow {
+public class GerritToolWindow implements Disposable {
     private static final Logger LOG = Logger.getInstance(GerritToolWindow.class);
 
     private final GerritUtil gerritUtil = GerritUtil.getInstance();
@@ -59,6 +60,14 @@ public class GerritToolWindow {
 
     private GerritChangeDetailsPanel detailsPanel;
 
+    /**
+     * Nothing to release here: this is the parent the tool window content's listeners are registered against, and
+     * the platform disposes it with the content.
+     */
+    @Override
+    public void dispose() {
+    }
+
     public SimpleToolWindowPanel createToolWindowContent(final Project project) {
         changeListPanel.setProject(project);
 
@@ -68,7 +77,7 @@ public class GerritToolWindow {
         toolbar.setTargetComponent(changeListPanel);
         panel.setToolbar(toolbar.getComponent());
 
-        CommittedChangesBrowser repositoryChangesBrowser = repositoryChangesBrowserProvider.get(project, changeListPanel);
+        CommittedChangesBrowser repositoryChangesBrowser = repositoryChangesBrowserProvider.get(project, changeListPanel, this);
 
         JBSplitter detailsSplitter = new OnePixelSplitter(true, 0.6f);
         detailsSplitter.setSplitterProportionKey("Gerrit.ListDetailSplitter.Proportion");
@@ -110,7 +119,7 @@ public class GerritToolWindow {
                 reloadChanges(project, false);
             }
         };
-        project.getMessageBus().connect().subscribe(VcsRepositoryManager.VCS_REPOSITORY_MAPPING_UPDATED, vcsListener);
+        project.getMessageBus().connect(this).subscribe(VcsRepositoryManager.VCS_REPOSITORY_MAPPING_UPDATED, vcsListener);
     }
 
     private void changeSelected(ChangeInfo changeInfo, final Project project) {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritToolWindowFactory.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritToolWindowFactory.java
@@ -39,6 +39,7 @@ public class GerritToolWindowFactory implements ToolWindowFactory, DumbAware {
 
         ContentManager contentManager = toolWindow.getContentManager();
         Content content = contentManager.getFactory().createContent(toolWindowContent, "", false);
+        content.setDisposer(gerritToolWindow);
         contentManager.addContent(content);
         contentManager.setSelectedContent(content);
     }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/RepositoryChangesBrowserProvider.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/RepositoryChangesBrowserProvider.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.google.gerrit.extensions.common.RevisionInfo;
 import com.intellij.diff.chains.DiffRequestChain;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.CommonShortcuts;
 import com.intellij.openapi.actionSystem.Separator;
@@ -72,9 +73,9 @@ public class RepositoryChangesBrowserProvider {
     private final GerritGitUtil gerritGitUtil = GerritGitUtil.getInstance();
     private final GerritUtil gerritUtil = GerritUtil.getInstance();
     private final NotificationService notificationService = NotificationService.getInstance();
-    private final GerritCommentCountChangeNodeDecorator commentCountChangeNodeDecorator = new GerritCommentCountChangeNodeDecorator();
     private final SelectedRevisions selectedRevisions = SelectedRevisions.getInstance();
 
+    private GerritCommentCountChangeNodeDecorator commentCountChangeNodeDecorator;
     private SelectBaseRevisionAction selectBaseRevisionAction;
 
     /**
@@ -84,12 +85,13 @@ public class RepositoryChangesBrowserProvider {
         return ImmutableList.<GerritChangeNodeDecorator>of(commentCountChangeNodeDecorator);
     }
 
-    public GerritRepositoryChangesBrowser get(Project project, GerritChangeListPanel changeListPanel) {
-        selectBaseRevisionAction = new SelectBaseRevisionAction(selectedRevisions);
+    public GerritRepositoryChangesBrowser get(Project project, GerritChangeListPanel changeListPanel, Disposable parent) {
+        commentCountChangeNodeDecorator = new GerritCommentCountChangeNodeDecorator(parent);
+        selectBaseRevisionAction = new SelectBaseRevisionAction(selectedRevisions, parent);
 
         TableView<ChangeInfo> table = changeListPanel.getTable();
 
-        final GerritRepositoryChangesBrowser changesBrowser = new GerritRepositoryChangesBrowser(project);
+        final GerritRepositoryChangesBrowser changesBrowser = new GerritRepositoryChangesBrowser(project, parent);
         changesBrowser.getDiffAction().registerCustomShortcutSet(CommonShortcuts.getDiff(), table);
         changesBrowser.getViewerScrollPane().setBorder(IdeBorderFactory.createBorder(SideBorder.LEFT | SideBorder.TOP));
         changesBrowser.setChangeNodeDecorator(changesBrowser.getChangeNodeDecorator());
@@ -108,7 +110,7 @@ public class RepositoryChangesBrowserProvider {
         private Optional<Pair<String, RevisionInfo>> baseRevision = Optional.absent();
         private Project project;
 
-        public GerritRepositoryChangesBrowser(Project project) {
+        public GerritRepositoryChangesBrowser(Project project, Disposable parent) {
             super(project);
             this.project = project;
             selectBaseRevisionAction.addRevisionSelectedListener(new SelectBaseRevisionAction.Listener() {
@@ -125,7 +127,7 @@ public class RepositoryChangesBrowserProvider {
                         updateChangesBrowser();
                     }
                 }
-            });
+            }, parent);
         }
 
         @Override

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/changesbrowser/SelectBaseRevisionAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/changesbrowser/SelectBaseRevisionAction.java
@@ -24,6 +24,7 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.google.gerrit.extensions.common.RevisionInfo;
+import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.UpdateInBackground;
@@ -60,7 +61,7 @@ public class SelectBaseRevisionAction extends BasePopupAction {
     private Optional<Pair<String, RevisionInfo>> selectedValue = Optional.absent();
     private List<Listener> listeners = Lists.newArrayList();
 
-    public SelectBaseRevisionAction(final SelectedRevisions selectedRevisions) {
+    public SelectBaseRevisionAction(final SelectedRevisions selectedRevisions, Disposable parent) {
         super("Diff against");
         this.selectedRevisions = selectedRevisions;
         selectedRevisions.addListener(new SelectedRevisions.Listener() {
@@ -74,7 +75,7 @@ public class SelectBaseRevisionAction extends BasePopupAction {
                     }
                 }
             }
-        });
+        }, parent);
         updateLabel();
     }
 


### PR DESCRIPTION
`SelectedRevisions` is an application service, so it outlives every listener registered on it. Three registrations never removed theirs:

- `GerritCommentCountChangeNodeDecorator`
- `SelectBaseRevisionAction`
- the changes browser in `RepositoryChangesBrowserProvider`

All three are built when a project's tool window content is created. Close the project and they stay registered on the still-living service — reacting to revision selections made in other projects, and holding the dead UI they captured.

The VCS repository mapping subscription in `GerritToolWindow` had the same shape: the no-arg `MessageBus#connect()` ties the connection to the project rather than to the content, and `createToolWindowContent` can run more than once.

`GerritToolWindow` is now the `Disposable` all of those hang off, and `GerritToolWindowFactory` hands it to the `Content` it creates via `setDisposer`, so the platform ends them together with the content.

`SelectedRevisions#addListener` now **takes** the parent disposable instead of offering an overload, so a registration cannot go unbounded by omission. That is the only signature change that reaches outside this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5uLNv1Xfpn5G6Xoj2cF26)_