### PR TITLE
Keep the selected revisions per project

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/SelectedRevisions.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/SelectedRevisions.java
@@ -21,8 +21,8 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.Service;
+import com.intellij.openapi.project.Project;
 import com.intellij.util.EventDispatcher;
 import org.jetbrains.annotations.Nullable;
 
@@ -35,13 +35,13 @@ import java.util.Set;
  *
  * @author Thomas Forrer
  */
-@Service(Service.Level.APP)
+@Service(Service.Level.PROJECT)
 public final class SelectedRevisions {
     private final Map<String, String> map = Maps.newHashMap();
     private final EventDispatcher<Listener> eventDispatcher = EventDispatcher.create(Listener.class);
 
-    public static SelectedRevisions getInstance() {
-        return ApplicationManager.getApplication().getService(SelectedRevisions.class);
+    public static SelectedRevisions getInstance(Project project) {
+        return project.getService(SelectedRevisions.class);
     }
 
     /**

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/extension/GerritCheckoutProvider.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/extension/GerritCheckoutProvider.java
@@ -95,7 +95,7 @@ public class GerritCheckoutProvider implements CheckoutProvider {
         ImmutableSortedSet<ProjectInfo> orderedProjects =
             ImmutableSortedSet.orderedBy(ID_REVERSE_ORDERING).addAll(availableProjects).build();
 
-        String url = getCloneBaseUrl();
+        String url = getCloneBaseUrl(project);
 
         final GitCloneDialog dialog = new GitCloneDialog(project);
         for (ProjectInfo projectInfo : orderedProjects) {
@@ -132,7 +132,7 @@ public class GerritCheckoutProvider implements CheckoutProvider {
      *
      * This can be cleaned up once https://code.google.com/p/gerrit/issues/detail?id=2208 is implemented.
      */
-    private String getCloneBaseUrl() {
+    private String getCloneBaseUrl(Project project) {
         if (!Strings.isNullOrEmpty(gerritSettings.getCloneBaseUrl())) {
             return gerritSettings.getCloneBaseUrl();
         }
@@ -147,7 +147,7 @@ public class GerritCheckoutProvider implements CheckoutProvider {
                 return url;
             }
             ChangeInfo changeInfo = Iterables.getOnlyElement(changeInfos);
-            FetchInfo fetchInfo = gerritUtil.getFirstFetchInfo(changeInfo);
+            FetchInfo fetchInfo = gerritUtil.getFirstFetchInfo(project, changeInfo);
             if (fetchInfo != null) {
                 String projectName = changeInfo.project;
                 url = fetchInfo.url.replaceAll("/" + projectName + "$", "");

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/GerritUtil.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/GerritUtil.java
@@ -623,11 +623,12 @@ public final class GerritUtil {
         });
     }
 
-    public FetchInfo getFirstFetchInfo(ChangeInfo changeDetails) {
+    public FetchInfo getFirstFetchInfo(Project project, ChangeInfo changeDetails) {
         if (changeDetails.revisions == null) {
             return null;
         }
-        RevisionInfo revisionInfo = changeDetails.revisions.get(SelectedRevisions.getInstance().get(changeDetails));
+        RevisionInfo revisionInfo =
+            changeDetails.revisions.get(SelectedRevisions.getInstance(project).get(changeDetails));
         return getFirstFetchInfo(revisionInfo);
     }
 

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritChangeListPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritChangeListPanel.java
@@ -87,9 +87,10 @@ public class GerritChangeListPanel extends JPanel implements Consumer<LoadChange
     private volatile boolean loadingMoreChanges = false;
     private final JScrollPane scrollPane;
 
-    public GerritChangeListPanel() {
-        this.selectedRevisions = SelectedRevisions.getInstance();
-        this.selectRevisionInfoColumn = new GerritSelectRevisionInfoColumn();
+    public GerritChangeListPanel(Project project) {
+        this.project = project;
+        this.selectedRevisions = SelectedRevisions.getInstance(project);
+        this.selectRevisionInfoColumn = new GerritSelectRevisionInfoColumn(project);
         this.gerritSettings = GerritSettings.getInstance();
         this.changes = Lists.newArrayList();
 
@@ -125,10 +126,6 @@ public class GerritChangeListPanel extends JPanel implements Consumer<LoadChange
             }
         });
         add(scrollPane);
-    }
-
-    public void setProject(Project project) {
-        this.project = project;
     }
 
     @Override

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritCommentCountChangeNodeDecorator.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritCommentCountChangeNodeDecorator.java
@@ -55,8 +55,8 @@ public class GerritCommentCountChangeNodeDecorator implements GerritChangeNodeDe
     private Supplier<Map<String, List<CommentInfo>>> drafts = setupDraftsSupplier();
     private Supplier<Set<String>> reviewed = setupReviewedSupplier();
 
-    public GerritCommentCountChangeNodeDecorator(Disposable parent) {
-        this.selectedRevisions = SelectedRevisions.getInstance();
+    public GerritCommentCountChangeNodeDecorator(Project project, Disposable parent) {
+        this.selectedRevisions = SelectedRevisions.getInstance(project);
         this.selectedRevisions.addListener(new SelectedRevisions.Listener() {
             @Override
             public void selectedRevisionChanged(String changeId) {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritSelectRevisionInfoColumn.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritSelectRevisionInfoColumn.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Maps;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.google.gerrit.extensions.common.RevisionInfo;
 import com.intellij.openapi.ui.ComboBoxTableRenderer;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
 import com.intellij.util.ui.ColumnInfo;
 import com.urswolfer.intellij.plugin.gerrit.SelectedRevisions;
@@ -51,7 +52,7 @@ import java.util.Set;
  * @author Thomas Forrer
  */
 public class GerritSelectRevisionInfoColumn extends ColumnInfo<ChangeInfo, String> {
-    private final SelectedRevisions selectedRevisions = SelectedRevisions.getInstance();
+    private final SelectedRevisions selectedRevisions;
 
     private static final Function<Map.Entry<String, RevisionInfo>, Pair<String, RevisionInfo>> MAP_ENTRY_TO_PAIR = new Function<Map.Entry<String, RevisionInfo>, Pair<String, RevisionInfo>>() {
         @Override
@@ -60,8 +61,9 @@ public class GerritSelectRevisionInfoColumn extends ColumnInfo<ChangeInfo, Strin
         }
     };
 
-    public GerritSelectRevisionInfoColumn() {
+    public GerritSelectRevisionInfoColumn(Project project) {
         super("Patch Set");
+        selectedRevisions = SelectedRevisions.getInstance(project);
     }
 
     @Nullable

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritToolWindow.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritToolWindow.java
@@ -54,7 +54,7 @@ public class GerritToolWindow implements Disposable {
 
     private final GerritUtil gerritUtil = GerritUtil.getInstance();
     private final GerritSettings gerritSettings = GerritSettings.getInstance();
-    private final GerritChangeListPanel changeListPanel = new GerritChangeListPanel();
+    private GerritChangeListPanel changeListPanel;
     private final GerritChangesFilters changesFilters = new GerritChangesFilters();
     private final RepositoryChangesBrowserProvider repositoryChangesBrowserProvider = new RepositoryChangesBrowserProvider();
 
@@ -69,7 +69,7 @@ public class GerritToolWindow implements Disposable {
     }
 
     public SimpleToolWindowPanel createToolWindowContent(final Project project) {
-        changeListPanel.setProject(project);
+        changeListPanel = new GerritChangeListPanel(project);
 
         SimpleToolWindowPanel panel = new SimpleToolWindowPanel(true, true);
 

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/RepositoryChangesBrowserProvider.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/RepositoryChangesBrowserProvider.java
@@ -73,9 +73,8 @@ public class RepositoryChangesBrowserProvider {
     private final GerritGitUtil gerritGitUtil = GerritGitUtil.getInstance();
     private final GerritUtil gerritUtil = GerritUtil.getInstance();
     private final NotificationService notificationService = NotificationService.getInstance();
-    private final SelectedRevisions selectedRevisions = SelectedRevisions.getInstance();
-
     private GerritCommentCountChangeNodeDecorator commentCountChangeNodeDecorator;
+    private SelectedRevisions selectedRevisions;
     private SelectBaseRevisionAction selectBaseRevisionAction;
 
     /**
@@ -86,7 +85,8 @@ public class RepositoryChangesBrowserProvider {
     }
 
     public GerritRepositoryChangesBrowser get(Project project, GerritChangeListPanel changeListPanel, Disposable parent) {
-        commentCountChangeNodeDecorator = new GerritCommentCountChangeNodeDecorator(parent);
+        selectedRevisions = SelectedRevisions.getInstance(project);
+        commentCountChangeNodeDecorator = new GerritCommentCountChangeNodeDecorator(project, parent);
         selectBaseRevisionAction = new SelectBaseRevisionAction(selectedRevisions, parent);
 
         TableView<ChangeInfo> table = changeListPanel.getTable();

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/CheckoutAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/CheckoutAction.java
@@ -49,7 +49,6 @@ import java.util.concurrent.Callable;
 public class CheckoutAction extends AbstractChangeAction {
     private final GerritGitUtil gerritGitUtil = GerritGitUtil.getInstance();
     private final FetchAction fetchAction = new FetchAction();
-    private final SelectedRevisions selectedRevisions = SelectedRevisions.getInstance();
     private final NotificationService notificationService = NotificationService.getInstance();
 
     public CheckoutAction() {
@@ -82,11 +81,11 @@ public class CheckoutAction extends AbstractChangeAction {
                             notificationService.notifyError(notification);
                             return null;
                         }
-                        String branchName = buildBranchName(changeDetails);
+                        String branchName = buildBranchName(project, changeDetails);
                         String checkedOutBranchName = branchName;
                         final GitRepository repository = gitRepositoryOptional.get();
                         final List<GitRepository> gitRepositories = Collections.singletonList(repository);
-                        FetchInfo firstFetchInfo = gerritUtil.getFirstFetchInfo(changeDetails);
+                        FetchInfo firstFetchInfo = gerritUtil.getFirstFetchInfo(project, changeDetails);
                         final Optional<GitRemote> remote = gerritGitUtil.getRemoteForChange(project, repository, firstFetchInfo);
                         if (!remote.isPresent()) {
                             return null;
@@ -130,8 +129,9 @@ public class CheckoutAction extends AbstractChangeAction {
         });
     }
 
-    private String buildBranchName(ChangeInfo changeDetails) {
-        RevisionInfo revisionInfo = changeDetails.revisions.get(selectedRevisions.get(changeDetails));
+    private String buildBranchName(Project project, ChangeInfo changeDetails) {
+        RevisionInfo revisionInfo = changeDetails.revisions.get(
+            SelectedRevisions.getInstance(project).get(changeDetails));
         String topic = changeDetails.topic;
         if (topic == null) {
             topic = Integer.toString(changeDetails._number);

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/CherryPickAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/CherryPickAction.java
@@ -34,7 +34,6 @@ import java.util.concurrent.Callable;
 public class CherryPickAction extends AbstractChangeAction {
     private final GerritGitUtil gerritGitUtil = GerritGitUtil.getInstance();
     private final FetchAction fetchAction = new FetchAction();
-    private final SelectedRevisions selectedRevisions = SelectedRevisions.getInstance();
 
     public CherryPickAction() {
         super("Cherry-Pick (No Commit)", "Cherry-Pick change into active changelist without committing", DvcsImplIcons.CherryPick);
@@ -57,7 +56,8 @@ public class CherryPickAction extends AbstractChangeAction {
                         ApplicationManager.getApplication().invokeLater(new Runnable() {
                             @Override
                             public void run() {
-                                gerritGitUtil.cherryPickChange(project, changeInfo, selectedRevisions.get(changeInfo));
+                                gerritGitUtil.cherryPickChange(project, changeInfo,
+                                    SelectedRevisions.getInstance(project).get(changeInfo));
                             }
                         });
                         return null;

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/FetchAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/FetchAction.java
@@ -37,7 +37,6 @@ public class FetchAction {
     private final GerritUtil gerritUtil = GerritUtil.getInstance();
     private final GerritGitUtil gerritGitUtil = GerritGitUtil.getInstance();
     private final NotificationService notificationService = NotificationService.getInstance();
-    private final SelectedRevisions selectedRevisions = SelectedRevisions.getInstance();
 
     public void fetchChange(ChangeInfo selectedChange, final Project project, final Callable<Void> fetchCallback) {
         gerritUtil.getChangeDetails(selectedChange._number, project, new Consumer<ChangeInfo>() {
@@ -52,9 +51,9 @@ public class FetchAction {
                     return;
                 }
 
-                String commitHash = selectedRevisions.get(changeDetails);
+                String commitHash = SelectedRevisions.getInstance(project).get(changeDetails);
 
-                FetchInfo firstFetchInfo = gerritUtil.getFirstFetchInfo(changeDetails);
+                FetchInfo firstFetchInfo = gerritUtil.getFirstFetchInfo(project, changeDetails);
                 if (firstFetchInfo == null) {
                     return;
                 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/ReviewAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/ReviewAction.java
@@ -42,7 +42,6 @@ import java.util.Map;
  */
 @SuppressWarnings("ComponentNotRegistered") // created per label and rating by ReviewActionGroup
 public class ReviewAction extends AbstractLoggedInChangeAction {
-    private final SelectedRevisions selectedRevisions = SelectedRevisions.getInstance();
     private final SubmitAction submitAction = new SubmitAction();
     private final NotificationService notificationService = NotificationService.getInstance();
 
@@ -66,7 +65,7 @@ public class ReviewAction extends AbstractLoggedInChangeAction {
             return;
         }
         final ChangeInfo changeDetails = selectedChange.get();
-        gerritUtil.getComments(changeDetails._number, selectedRevisions.get(changeDetails), project, false, true,
+        gerritUtil.getComments(changeDetails._number, SelectedRevisions.getInstance(project).get(changeDetails), project, false, true,
                 new Consumer<Map<String, List<CommentInfo>>>() {
             @Override
             public void consume(Map<String, List<CommentInfo>> draftComments) {
@@ -99,7 +98,7 @@ public class ReviewAction extends AbstractLoggedInChangeAction {
 
                 final boolean finalSubmitChange = submitChange;
                 gerritUtil.postReview(changeDetails.id,
-                        selectedRevisions.get(changeDetails),
+                        SelectedRevisions.getInstance(project).get(changeDetails),
                         reviewInput,
                         project,
                         new Consumer<Void>() {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/CommentsDiffTool.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/CommentsDiffTool.java
@@ -98,7 +98,6 @@ public class CommentsDiffTool implements FrameDiffTool, SuppressiveDiffTool {
     private final GerritUtil gerritUtil = GerritUtil.getInstance();
     private final GerritSettings gerritSettings = GerritSettings.getInstance();
     private final AddCommentActionBuilder addCommentActionBuilder = new AddCommentActionBuilder();
-    private final SelectedRevisions selectedRevisions = SelectedRevisions.getInstance();
 
     @NotNull
     @Override
@@ -281,7 +280,8 @@ public class CommentsDiffTool implements FrameDiffTool, SuppressiveDiffTool {
                                   @Nullable EditorEx editor1, EditorEx editor2) {
         ChangeInfo changeInfo = diffContext.getUserData(GerritUserDataKeys.CHANGE);
         Optional<Pair<String, RevisionInfo>> baseRevision = diffContext.getUserData(GerritUserDataKeys.BASE_REVISION);
-        String selectedRevisionId = changeInfo != null ? selectedRevisions.get(changeInfo) : null;
+        String selectedRevisionId = changeInfo != null
+            ? SelectedRevisions.getInstance(diffContext.getProject()).get(changeInfo) : null;
         Change change = diffRequest.getUserData(ChangeDiffRequestProducer.CHANGE_KEY);
         handleComments(editor1, editor2, change, diffContext.getProject(), changeInfo, selectedRevisionId, baseRevision);
     }


### PR DESCRIPTION
`SelectedRevisions` was an application service, but everything it records — which patch set the user picked for a given change — belongs to one project's change list.

With two projects open they shared a single map, and `GerritChangeListPanel` calls `clear()` on every reload. So refreshing one project's change list silently discarded the revisions selected in the other. It is a project service now, resolved from the project each caller already had to hand.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5uLNv1Xfpn5G6Xoj2cF26)_