### PR TITLE
Follow the platform's conventions in four small places

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/GerritSettings.java
@@ -25,6 +25,7 @@ import com.intellij.credentialStore.Credentials;
 import com.intellij.ide.passwordSafe.PasswordSafe;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.PersistentStateComponent;
+import com.intellij.openapi.components.Service;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.openapi.diagnostic.Logger;
@@ -40,8 +41,9 @@ import org.jetbrains.annotations.Nullable;
  * @author oleg
  * @author Urs Wolfer
  */
+@Service(Service.Level.APP)
 @State(name = "GerritSettings", storages = @Storage("gerrit_settings.xml"))
-public class GerritSettings implements PersistentStateComponent<Element>, GerritAuthData {
+public final class GerritSettings implements PersistentStateComponent<Element>, GerritAuthData {
 
     private static final Logger LOG = Logger.getInstance(GerritSettings.class);
 

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/extension/GerritCheckoutProvider.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/extension/GerritCheckoutProvider.java
@@ -29,7 +29,6 @@ import com.google.gerrit.extensions.common.FetchInfo;
 import com.google.gerrit.extensions.common.ProjectInfo;
 import com.google.gerrit.extensions.restapi.RestApiException;
 import com.google.gerrit.extensions.restapi.Url;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
@@ -115,7 +114,7 @@ public class GerritCheckoutProvider implements CheckoutProvider {
         final String directoryName = dialog.getDirectoryName();
         final String parentDirectory = dialog.getParentDirectory();
 
-        Git git = ApplicationManager.getApplication().getService(Git.class);
+        Git git = Git.getInstance();
 
         Listener listenerWrapper = addCommitMsgHookListener(listener, directoryName, parentDirectory, project);
 

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritCommentCountChangeNodeDecorator.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritCommentCountChangeNodeDecorator.java
@@ -46,7 +46,6 @@ public class GerritCommentCountChangeNodeDecorator implements GerritChangeNodeDe
 
     private static final Joiner SUFFIX_JOINER = Joiner.on(", ").skipNulls();
 
-    private final PathUtils pathUtils = PathUtils.getInstance();
     private final GerritSettings gerritSettings = GerritSettings.getInstance();
 
     private final SelectedRevisions selectedRevisions;
@@ -129,7 +128,7 @@ public class GerritCommentCountChangeNodeDecorator implements GerritChangeNodeDe
     }
 
     private String getRelativeOrAbsolutePath(Project project, String absoluteFilePath) {
-        return pathUtils.getRelativeOrAbsolutePath(project, absoluteFilePath, selectedChange.project);
+        return PathUtils.getRelativeOrAbsolutePath(project, absoluteFilePath, selectedChange.project);
     }
 
     private Supplier<Map<String, List<CommentInfo>>> setupCommentsSupplier() {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/AbandonAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/AbandonAction.java
@@ -23,7 +23,6 @@ import com.google.gerrit.extensions.common.ActionInfo;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.urswolfer.intellij.plugin.gerrit.ui.SafeHtmlTextEditor;
@@ -62,7 +61,7 @@ public class AbandonAction extends AbstractLoggedInChangeAction {
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent) {
-        final Project project = anActionEvent.getData(PlatformDataKeys.PROJECT);
+        final Project project = anActionEvent.getProject();
 
         Optional<ChangeInfo> selectedChange = getSelectedChange(anActionEvent);
         if (!selectedChange.isPresent()) {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/AddReviewersAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/AddReviewersAction.java
@@ -28,7 +28,6 @@ import com.intellij.codeInsight.completion.CompletionResultSet;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.SpellCheckingEditorCustomizationProvider;
 import com.intellij.openapi.fileTypes.FileTypes;
@@ -59,7 +58,7 @@ public class AddReviewersAction extends AbstractLoggedInChangeAction {
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent) {
-        final Project project = anActionEvent.getData(PlatformDataKeys.PROJECT);
+        final Project project = anActionEvent.getProject();
 
         Optional<ChangeInfo> selectedChange = getSelectedChange(anActionEvent);
         if (!selectedChange.isPresent()) {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/CherryPickAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/CherryPickAction.java
@@ -19,7 +19,6 @@ package com.urswolfer.intellij.plugin.gerrit.ui.action;
 import com.google.common.base.Optional;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.Consumer;
@@ -47,7 +46,7 @@ public class CherryPickAction extends AbstractChangeAction {
         if (!selectedChange.isPresent()) {
             return;
         }
-        final Project project = anActionEvent.getData(PlatformDataKeys.PROJECT);
+        final Project project = anActionEvent.getProject();
 
         getChangeDetail(selectedChange.get(), project, new Consumer<ChangeInfo>() {
             @Override

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/CompareBranchAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/CompareBranchAction.java
@@ -22,7 +22,6 @@ import com.intellij.dvcs.ui.CompareBranchesDialog;
 import com.intellij.dvcs.util.CommitCompareInfo;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
 import com.urswolfer.intellij.plugin.gerrit.git.GerritGitUtil;
@@ -53,7 +52,7 @@ public class CompareBranchAction extends AbstractChangeAction {
         if (!selectedChange.isPresent()) {
             return;
         }
-        final Project project = anActionEvent.getData(PlatformDataKeys.PROJECT);
+        final Project project = anActionEvent.getProject();
         Callable<Void> successCallable = new Callable<Void>() {
             @Override
             public Void call() throws Exception {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/CopyChangeIdAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/CopyChangeIdAction.java
@@ -20,7 +20,6 @@ import com.google.common.base.Optional;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.ide.CopyPasteManager;
 import com.intellij.openapi.project.Project;
 import com.urswolfer.intellij.plugin.gerrit.util.NotificationBuilder;
@@ -47,7 +46,7 @@ public class CopyChangeIdAction extends AbstractChangeAction {
         ChangeInfo changeDetails = selectedChange.get();
         String stringToCopy = changeDetails.changeId;
         CopyPasteManager.getInstance().setContents(new StringSelection(stringToCopy));
-        Project project = anActionEvent.getData(PlatformDataKeys.PROJECT);
+        Project project = anActionEvent.getProject();
         NotificationBuilder builder = new NotificationBuilder(project, "Copy", "Copied Change-ID to clipboard.");
         notificationService.notify(builder);
     }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/DeleteAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/DeleteAction.java
@@ -22,7 +22,6 @@ import com.google.gerrit.extensions.common.ActionInfo;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.project.Project;
 
 /**
@@ -65,7 +64,7 @@ public class DeleteAction extends AbstractLoggedInChangeAction {
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent) {
-        Project project = anActionEvent.getData(PlatformDataKeys.PROJECT);
+        Project project = anActionEvent.getProject();
         Optional<ChangeInfo> selectedChange = getSelectedChange(anActionEvent);
         if (!selectedChange.isPresent()) {
             return;

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/PublishAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/PublishAction.java
@@ -22,7 +22,6 @@ import com.google.gerrit.extensions.common.ActionInfo;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.project.Project;
 
 import java.util.Map;
@@ -63,7 +62,7 @@ public class PublishAction extends AbstractLoggedInChangeAction {
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent) {
-        Project project = anActionEvent.getData(PlatformDataKeys.PROJECT);
+        Project project = anActionEvent.getProject();
 
         Optional<ChangeInfo> selectedChange = getSelectedChange(anActionEvent);
         if (!selectedChange.isPresent()) {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/RefreshAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/RefreshAction.java
@@ -19,7 +19,6 @@ package com.urswolfer.intellij.plugin.gerrit.ui.action;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
@@ -37,7 +36,7 @@ public class RefreshAction extends AnAction implements DumbAware, UpdateInBackgr
 
     @Override
     public void actionPerformed(AnActionEvent e) {
-        Project project = e.getData(PlatformDataKeys.PROJECT);
+        Project project = e.getProject();
         GerritToolWindowFactory.ProjectService projectService = project.getService(GerritToolWindowFactory.ProjectService.class);
         GerritToolWindow gerritToolWindow = projectService.getGerritToolWindow();
         gerritToolWindow.reloadChanges(project, true);

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/ReviewAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/ReviewAction.java
@@ -26,7 +26,6 @@ import com.google.gerrit.extensions.api.changes.ReviewInput;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.google.gerrit.extensions.common.CommentInfo;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.Consumer;
 import com.urswolfer.intellij.plugin.gerrit.SelectedRevisions;
@@ -60,7 +59,7 @@ public class ReviewAction extends AbstractLoggedInChangeAction {
 
     @Override
     public void actionPerformed(final AnActionEvent anActionEvent) {
-        final Project project = anActionEvent.getData(PlatformDataKeys.PROJECT);
+        final Project project = anActionEvent.getProject();
 
         Optional<ChangeInfo> selectedChange = getSelectedChange(anActionEvent);
         if (!selectedChange.isPresent()) {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/SettingsAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/SettingsAction.java
@@ -19,7 +19,6 @@ package com.urswolfer.intellij.plugin.gerrit.ui.action;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.options.ShowSettingsUtil;
 import com.intellij.openapi.project.DumbAware;
@@ -38,7 +37,7 @@ public class SettingsAction extends AnAction implements DumbAware, UpdateInBackg
 
     @Override
     public void actionPerformed(AnActionEvent anActionEvent) {
-        final Project project = anActionEvent.getData(PlatformDataKeys.PROJECT);
+        final Project project = anActionEvent.getProject();
         ShowSettingsUtil.getInstance().showSettingsDialog(project, GerritSettingsConfigurable.NAME);
     }
 

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/StarAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/StarAction.java
@@ -4,7 +4,6 @@ import com.google.common.base.Optional;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.project.Project;
 
 /**
@@ -22,7 +21,7 @@ public class StarAction extends AbstractLoggedInChangeAction {
         if (!selectedChange.isPresent()) {
             return;
         }
-        Project project = anActionEvent.getData(PlatformDataKeys.PROJECT);
+        Project project = anActionEvent.getProject();
         ChangeInfo changeInfo = selectedChange.get();
         gerritUtil.changeStarredStatus(changeInfo.id, !(changeInfo.starred != null && changeInfo.starred), project);
     }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/SubmitAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/SubmitAction.java
@@ -21,7 +21,6 @@ import com.google.gerrit.extensions.api.changes.SubmitInput;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.Consumer;
 import com.urswolfer.intellij.plugin.gerrit.util.NotificationBuilder;
@@ -57,7 +56,7 @@ public class SubmitAction extends AbstractLoggedInChangeAction {
 
     /** Entry point for other actions; {@code actionPerformed} is override-only and must not be invoked. */
     public void submit(AnActionEvent anActionEvent) {
-        final Project project = anActionEvent.getData(PlatformDataKeys.PROJECT);
+        final Project project = anActionEvent.getProject();
 
         final Optional<ChangeInfo> selectedChange = getSelectedChange(anActionEvent);
         if (!selectedChange.isPresent()) {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/AddCommentAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/AddCommentAction.java
@@ -23,7 +23,6 @@ import com.google.gerrit.extensions.common.ChangeInfo;
 import com.google.gerrit.extensions.common.CommentInfo;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.markup.RangeHighlighter;
@@ -94,7 +93,7 @@ public class AddCommentAction extends AnAction implements DumbAware, UpdateInBac
     }
 
     public void actionPerformed(AnActionEvent e) {
-        final Project project = e.getData(PlatformDataKeys.PROJECT);
+        final Project project = e.getProject();
         if (project == null) return;
         addVersionedComment(project);
     }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/CommentDoneAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/CommentDoneAction.java
@@ -23,7 +23,6 @@ import com.google.gerrit.extensions.common.CommentInfo;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.DumbAware;
@@ -73,7 +72,7 @@ public class CommentDoneAction extends AnAction implements DumbAware, UpdateInBa
         comment.side = fileComment.side;
         comment.range = fileComment.range;
 
-        final Project project = e.getData(PlatformDataKeys.PROJECT);
+        final Project project = e.getProject();
         gerritUtil.saveDraftComment(changeInfo._number, revisionId, comment, project,
                 new Consumer<CommentInfo>() {
                     @Override

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/CommentsDiffTool.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/CommentsDiffTool.java
@@ -98,7 +98,6 @@ public class CommentsDiffTool implements FrameDiffTool, SuppressiveDiffTool {
     private final GerritUtil gerritUtil = GerritUtil.getInstance();
     private final GerritSettings gerritSettings = GerritSettings.getInstance();
     private final AddCommentActionBuilder addCommentActionBuilder = new AddCommentActionBuilder();
-    private final PathUtils pathUtils = PathUtils.getInstance();
     private final SelectedRevisions selectedRevisions = SelectedRevisions.getInstance();
 
     @NotNull
@@ -312,7 +311,7 @@ public class CommentsDiffTool implements FrameDiffTool, SuppressiveDiffTool {
     }
 
     private String getRelativeOrAbsolutePath(Project project, String absoluteFilePath, ChangeInfo changeInfo) {
-        return pathUtils.getRelativeOrAbsolutePath(project, absoluteFilePath, changeInfo.project);
+        return PathUtils.getRelativeOrAbsolutePath(project, absoluteFilePath, changeInfo.project);
     }
 
     private static RangeHighlighter highlightRangeComment(Comment.Range range, Editor editor, Project project) {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/RemoveCommentAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/RemoveCommentAction.java
@@ -21,7 +21,6 @@ import com.google.gerrit.extensions.common.ChangeInfo;
 import com.intellij.icons.AllIcons;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.markup.RangeHighlighter;
@@ -67,7 +66,7 @@ public class RemoveCommentAction extends AnAction implements DumbAware, UpdateIn
 
     @Override
     public void actionPerformed(AnActionEvent e) {
-        final Project project = e.getData(PlatformDataKeys.PROJECT);
+        final Project project = e.getProject();
         gerritUtil.deleteDraftComment(changeInfo._number, revisionId, comment.id, project,
                 new Consumer<Void>() {
                     @Override

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/PathUtils.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/PathUtils.java
@@ -19,8 +19,6 @@
 package com.urswolfer.intellij.plugin.gerrit.util;
 
 import com.google.common.base.Optional;
-import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.components.Service;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -32,14 +30,11 @@ import java.io.File;
 /**
  * @author Thomas Forrer
  */
-@Service(Service.Level.APP)
 public final class PathUtils {
 
-    public static PathUtils getInstance() {
-        return ApplicationManager.getApplication().getService(PathUtils.class);
-    }
+    private PathUtils() {}
 
-    public String getRelativePath(Project project, String absoluteFilePath, String gerritProjectName) {
+    public static String getRelativePath(Project project, String absoluteFilePath, String gerritProjectName) {
         Optional<GitRepository> gitRepositoryOptional = GerritGitUtil.getInstance().getRepositoryForGerritProject(project, gerritProjectName);
         if (!gitRepositoryOptional.isPresent()) return null;
         GitRepository repository = gitRepositoryOptional.get();
@@ -50,7 +45,7 @@ public final class PathUtils {
     /**
      * @return a relative path for all files under the project root, or the absolute path for other files
      */
-    public String getRelativeOrAbsolutePath(Project project, String absoluteFilePath, String gerritProjectName) {
+    public static String getRelativeOrAbsolutePath(Project project, String absoluteFilePath, String gerritProjectName) {
         String relativePath = getRelativePath(project, absoluteFilePath, gerritProjectName);
         if (relativePath == null || relativePath.contains(File.separator + "..")) {
             return absoluteFilePath;

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -529,8 +529,6 @@
   <extensions defaultExtensionNs="com.intellij">
     <postStartupActivity implementation="com.urswolfer.intellij.plugin.gerrit.ui.GerritUpdatesNotificationStartupActivity"/>
     <checkoutProvider implementation="com.urswolfer.intellij.plugin.gerrit.extension.GerritCheckoutProvider"/>
-    <applicationService serviceInterface="com.urswolfer.intellij.plugin.gerrit.GerritSettings"
-                        serviceImplementation="com.urswolfer.intellij.plugin.gerrit.GerritSettings"/>
     <vcsConfigurableProvider implementation="com.urswolfer.intellij.plugin.gerrit.ui.GerritSettingsConfigurable"/>
 
     <toolWindow id="Gerrit" icon="MyIcons.Gerrit" anchor="bottom"


### PR DESCRIPTION
Four unrelated tidy-ups left over from the Guice removal. None changes behaviour.

**`GerritSettings` is a light service.** It was the only service still registered in `plugin.xml` while the other seven declare themselves on the class. Light services support `@State`, and the `@State(name = "GerritSettings")` is unchanged, so persisted settings load exactly as before. I left it alone during #574 to avoid churning a `PersistentStateComponent` mid-migration; now it is the odd one out. It gains `final` — nothing subclasses it.

**`PathUtils` is no longer a service.** It held no state: both instance methods only forwarded to `GerritGitUtil`, sitting next to a static that callers already used as one. They are static now, and the class has a private constructor.

**`GerritCheckoutProvider`** asked `ApplicationManager.getApplication().getService(Git.class)` where everything else, since #570, calls `Git.getInstance()`.

**Fifteen actions** read the project with `e.getData(PlatformDataKeys.PROJECT)` where `AnActionEvent` offers `getProject()`. Purely cosmetic; the import goes with it where it was the only use.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5uLNv1Xfpn5G6Xoj2cF26)_