### PR TITLE
Register the "gerrit" notification group

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -527,6 +527,9 @@
   </applicationListeners>
 
   <extensions defaultExtensionNs="com.intellij">
+    <notificationGroup id="gerrit" displayType="BALLOON"
+                       bundle="messages.GerritBundle" key="notification.group.gerrit"/>
+
     <postStartupActivity implementation="com.urswolfer.intellij.plugin.gerrit.ui.GerritUpdatesNotificationStartupActivity"/>
     <checkoutProvider implementation="com.urswolfer.intellij.plugin.gerrit.extension.GerritCheckoutProvider"/>
     <vcsConfigurableProvider implementation="com.urswolfer.intellij.plugin.gerrit.ui.GerritSettingsConfigurable"/>

--- a/src/main/resources/messages/GerritBundle.properties
+++ b/src/main/resources/messages/GerritBundle.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2026 Urs Wolfer
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+notification.group.gerrit=Gerrit


### PR DESCRIPTION
`NotificationBuilder` creates every notification with the group id `gerrit`, but that group was never declared in `plugin.xml`. The Settings | Notifications table is built from the *registered* groups (`NotificationsConfigurationImpl.getAllSettings()`), so the group never showed up there and users had no way to change its display type, logging or sound — the platform simply fell back to `getDefaultSettings()` for the unknown id.

## Changes

- Declare the group via the `notificationGroup` extension point, keeping exactly what the implicit fallback provided (`BALLOON`, logged by default), so existing behaviour is unchanged — the entry is just visible and editable now.
- Add `messages/GerritBundle.properties` so the settings entry reads "Gerrit" instead of the raw group id. Without `bundle`/`key`, `NotificationGroupEP.getDisplayName()` returns the id, which `NotificationSettingsWrapper.toString()` renders verbatim as a lowercase "gerrit" row. Using a bundle key avoids renaming the group id, which `NotificationBuilder` references.

`NotificationBuilder` itself is untouched: the `Notification(String groupId, …)` constructor is not deprecated in the 2020.3 platform this branch targets, so switching to `NotificationGroupManager` would be churn beyond this fix.

## Verification

`./gradlew build` is green in CI: `verifyPluginConfiguration`, `instrumentCode`, `buildSearchableOptions` (which boots IC-203.8084.24 with the plugin installed) and `test` all pass, and the bundle lands at `build/resources/main/messages/` so `messages.GerritBundle` resolves in the packaged jar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015WLneeykoxRcCVWyrtwRgq