### PR TITLE
Replace ProjectService with DataKey for GerritToolWindow access

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritToolWindow.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritToolWindow.java
@@ -25,6 +25,7 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.actionSystem.ActionManager;
 import com.intellij.openapi.actionSystem.ActionToolbar;
 import com.intellij.openapi.actionSystem.Constraints;
+import com.intellij.openapi.actionSystem.DataKey;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.actionSystem.Separator;
 import com.intellij.openapi.diagnostic.Logger;
@@ -41,6 +42,7 @@ import com.urswolfer.intellij.plugin.gerrit.ui.filter.ChangesFilter;
 import com.urswolfer.intellij.plugin.gerrit.ui.filter.GerritChangesFilters;
 import git4idea.GitUtil;
 import git4idea.repo.GitRepository;
+import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
 import java.util.List;
@@ -50,6 +52,12 @@ import java.util.List;
  * @author Konrad Dobrzynski
  */
 public class GerritToolWindow implements Disposable {
+    /**
+     * Provided by the tool window content panel, so that actions can reach the tool window they were invoked from
+     * instead of looking it up in a global holder.
+     */
+    public static final DataKey<GerritToolWindow> GERRIT_TOOL_WINDOW = DataKey.create("Gerrit.ToolWindow");
+
     private static final Logger LOG = Logger.getInstance(GerritToolWindow.class);
 
     private final GerritUtil gerritUtil = GerritUtil.getInstance();
@@ -71,7 +79,15 @@ public class GerritToolWindow implements Disposable {
     public SimpleToolWindowPanel createToolWindowContent(final Project project) {
         changeListPanel = new GerritChangeListPanel(project);
 
-        SimpleToolWindowPanel panel = new SimpleToolWindowPanel(true, true);
+        SimpleToolWindowPanel panel = new SimpleToolWindowPanel(true, true) {
+            @Override
+            public Object getData(@NotNull String dataId) {
+                if (GERRIT_TOOL_WINDOW.is(dataId)) {
+                    return GerritToolWindow.this;
+                }
+                return super.getData(dataId);
+            }
+        };
 
         ActionToolbar toolbar = createToolbar(project);
         toolbar.setTargetComponent(changeListPanel);

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritToolWindowFactory.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritToolWindowFactory.java
@@ -31,10 +31,6 @@ public class GerritToolWindowFactory implements ToolWindowFactory, DumbAware {
     @Override
     public void createToolWindowContent(final Project project, ToolWindow toolWindow) {
         GerritToolWindow gerritToolWindow = new GerritToolWindow();
-
-        ProjectService projectService = project.getService(ProjectService.class);
-        projectService.setGerritToolWindow(gerritToolWindow);
-
         SimpleToolWindowPanel toolWindowContent = gerritToolWindow.createToolWindowContent(project);
 
         ContentManager contentManager = toolWindow.getContentManager();
@@ -42,18 +38,5 @@ public class GerritToolWindowFactory implements ToolWindowFactory, DumbAware {
         content.setDisposer(gerritToolWindow);
         contentManager.addContent(content);
         contentManager.setSelectedContent(content);
-    }
-
-    public static class ProjectService {
-
-        private GerritToolWindow gerritToolWindow;
-
-        public GerritToolWindow getGerritToolWindow() {
-            return gerritToolWindow;
-        }
-
-        void setGerritToolWindow(GerritToolWindow gerritToolWindow) {
-            this.gerritToolWindow = gerritToolWindow;
-        }
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/RefreshAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/RefreshAction.java
@@ -23,7 +23,6 @@ import com.intellij.openapi.actionSystem.UpdateInBackground;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.urswolfer.intellij.plugin.gerrit.ui.GerritToolWindow;
-import com.urswolfer.intellij.plugin.gerrit.ui.GerritToolWindowFactory;
 import com.urswolfer.intellij.plugin.gerrit.ui.GerritUpdatesNotificationComponent;
 
 /**
@@ -35,10 +34,18 @@ public class RefreshAction extends AnAction implements DumbAware, UpdateInBackgr
     }
 
     @Override
+    public void update(AnActionEvent e) {
+        e.getPresentation().setEnabled(e.getProject() != null
+            && e.getData(GerritToolWindow.GERRIT_TOOL_WINDOW) != null);
+    }
+
+    @Override
     public void actionPerformed(AnActionEvent e) {
         Project project = e.getProject();
-        GerritToolWindowFactory.ProjectService projectService = project.getService(GerritToolWindowFactory.ProjectService.class);
-        GerritToolWindow gerritToolWindow = projectService.getGerritToolWindow();
+        GerritToolWindow gerritToolWindow = e.getData(GerritToolWindow.GERRIT_TOOL_WINDOW);
+        if (project == null || gerritToolWindow == null) {
+            return;
+        }
         gerritToolWindow.reloadChanges(project, true);
         GerritUpdatesNotificationComponent.getInstance(project).handleNotification();
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -537,8 +537,6 @@
     <toolWindow id="Gerrit" icon="MyIcons.Gerrit" anchor="bottom"
                 factoryClass="com.urswolfer.intellij.plugin.gerrit.ui.GerritToolWindowFactory"/>
     <projectService serviceImplementation="com.urswolfer.intellij.plugin.gerrit.ui.GerritUpdatesNotificationComponent"/>
-    <projectService serviceInterface="com.urswolfer.intellij.plugin.gerrit.ui.GerritToolWindowFactory$ProjectService"
-                    serviceImplementation="com.urswolfer.intellij.plugin.gerrit.ui.GerritToolWindowFactory$ProjectService" />
     <diff.DiffTool implementation="com.urswolfer.intellij.plugin.gerrit.ui.diff.CommentsDiffTool"/>
 
     <errorHandler implementation="com.urswolfer.intellij.plugin.gerrit.errorreport.PluginErrorReportSubmitter"/>


### PR DESCRIPTION
## Summary
Refactored the way actions access the `GerritToolWindow` instance by replacing a global `ProjectService` holder with IntelliJ's `DataKey` mechanism. This improves code maintainability and follows IntelliJ platform best practices for passing context to actions.

## Key Changes
- Added `GERRIT_TOOL_WINDOW` as a public static `DataKey` in `GerritToolWindow` to provide the tool window instance through the action system's data context
- Modified `SimpleToolWindowPanel` creation to override `getData()` and expose the `GerritToolWindow` instance via the `DataKey`
- Removed the `ProjectService` inner class from `GerritToolWindowFactory` that was previously used as a global holder
- Updated `RefreshAction` to:
  - Retrieve `GerritToolWindow` directly from action event data using `e.getData(GerritToolWindow.GERRIT_TOOL_WINDOW)`
  - Added `update()` method to enable/disable the action based on tool window availability
  - Removed dependency on `GerritToolWindowFactory.ProjectService`
- Removed the `projectService` registration from `plugin.xml`

## Implementation Details
The `DataKey` approach is more robust than a global service holder because:
- Actions receive the tool window instance directly through the action event's data context
- The tool window is only accessible when the action is invoked from within the tool window
- Eliminates the need for a separate service class and its lifecycle management
- Follows IntelliJ platform conventions for context passing in the action system

https://claude.ai/code/session_01K8rhSGuSpMbbzB2XZqwEWA