### PR TITLE
Fix wrong percent-encoding of the patch set description

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/UrlUtils.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/UrlUtils.java
@@ -51,7 +51,7 @@ public class UrlUtils {
         // at least the chars %^@.~-+_:/! must be percent-encoded and the space character must be encoded as '+'
         return URLEncoder.encode(text, StandardCharsets.UTF_8)
             .replace(".", "%2E")
-            .replace("-", "%96")
-            .replace("_", "%5E");
+            .replace("-", "%2D")
+            .replace("_", "%5F");
     }
 }

--- a/src/test/java/com/urswolfer/intellij/plugin/gerrit/util/UrlUtilsTest.java
+++ b/src/test/java/com/urswolfer/intellij/plugin/gerrit/util/UrlUtilsTest.java
@@ -20,6 +20,8 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author Urs Wolfer
@@ -63,6 +65,7 @@ public class UrlUtilsTest {
     @Test
     public void testPatchSetDescriptionEncoding() throws Exception {
         String encoded = UrlUtils.encodePatchSetDescription("Abc %^@.~-+_:/!");
-        Assert.assertEquals(encoded, "Abc+%25%5E%40%2E%7E%96%2B%5E%3A%2F%21");
+        Assert.assertEquals(encoded, "Abc+%25%5E%40%2E%7E%2D%2B%5F%3A%2F%21");
+        Assert.assertEquals(URLDecoder.decode(encoded, StandardCharsets.UTF_8), "Abc %^@.~-+_:/!");
     }
 }


### PR DESCRIPTION
`UrlUtils.encodePatchSetDescription()` percent-encodes `.`, `-` and `_` by hand on top of `URLEncoder` (which leaves those unreserved characters untouched, while Gerrit wants them encoded). Two of the three replacements used the wrong code point:

| character | encoded as | correct |
|---|---|---|
| `-` (0x2D) | `%96` — not a valid UTF-8 byte | `%2D` |
| `_` (0x5F) | `%5E` — this is `^` | `%5F` |

So the `m=` push option carried corrupted text. Running the current code:

```
input:  fix well-known bug_2.
sent:   fix+well%96known+bug%5E2%2E
Gerrit: fix well<invalid byte>known bug^2.
```

### Change

* use `%2D` / `%5F`
* the existing test asserted the broken output, so it is updated, and it now also asserts that the encoded value decodes back to the original text

https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR)_