### PR TITLE
Mark only really new changes as NEW in the review notification

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationComponent.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritUpdatesNotificationComponent.java
@@ -113,7 +113,7 @@ public final class GerritUpdatesNotificationComponent implements Consumer<List<C
             for (ChangeInfo change : changes) {
                 stringBuilder
                         .append("<li>")
-                        .append(!notifiedChanges.contains(change.changeId) ? "<strong>NEW: </strong>" : "")
+                        .append(!notifiedChanges.contains(change.id) ? "<strong>NEW: </strong>" : "")
                         .append(change.project)
                         .append(": ")
                         .append(change.subject)


### PR DESCRIPTION
`GerritUpdatesNotificationComponent` remembers which changes were already reported in `notifiedChanges`, filled with and checked against `ChangeInfo.id` (`project~branch~I…`). The per-entry marker in the notification body, however, compared `ChangeInfo.changeId` (`I…`) against that same set:

```java
.append(!notifiedChanges.contains(change.changeId) ? "<strong>NEW: </strong>" : "")
...
notifiedChanges.add(change.id);
```

`changeId` is never contained in the set, so **every** entry of **every** "Gerrit Changes waiting for my review" notification was rendered as `NEW:`, including changes that had already been reported in an earlier notification. The decision whether to show a notification at all already used `change.id` and was correct.

### Change

One-line fix: compare `change.id`, consistent with what is stored.

https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR)_