### PR TITLE
Detect relative paths which leave the repository root

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/PathUtils.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/PathUtils.java
@@ -24,6 +24,7 @@ import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.urswolfer.intellij.plugin.gerrit.git.GerritGitUtil;
 import git4idea.repo.GitRepository;
+import org.jetbrains.annotations.VisibleForTesting;
 
 import java.io.File;
 
@@ -47,10 +48,24 @@ public final class PathUtils {
      */
     public static String getRelativeOrAbsolutePath(Project project, String absoluteFilePath, String gerritProjectName) {
         String relativePath = getRelativePath(project, absoluteFilePath, gerritProjectName);
-        if (relativePath == null || relativePath.contains(File.separator + "..")) {
+        if (relativePath == null || leavesRepositoryRoot(relativePath)) {
             return absoluteFilePath;
         }
         return relativePath;
+    }
+
+    /**
+     * A relative path which walks out of the repository root does not denote a file of the Gerrit project,
+     * so the absolute path has to be used for it. Note that such a path can also start with "..".
+     */
+    @VisibleForTesting
+    static boolean leavesRepositoryRoot(String relativePath) {
+        for (String pathSegment : ensureSlashSeparators(relativePath).split("/")) {
+            if ("..".equals(pathSegment)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/test/java/com/urswolfer/intellij/plugin/gerrit/util/PathUtilsTest.java
+++ b/src/test/java/com/urswolfer/intellij/plugin/gerrit/util/PathUtilsTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.urswolfer.intellij.plugin.gerrit.util;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PathUtilsTest {
+
+    @Test
+    public void testPathInsideRepositoryRoot() throws Exception {
+        Assert.assertFalse(PathUtils.leavesRepositoryRoot("src/main/java/Foo.java"));
+        Assert.assertFalse(PathUtils.leavesRepositoryRoot("src\\main\\java\\Foo.java"));
+        Assert.assertFalse(PathUtils.leavesRepositoryRoot("Foo.java"));
+        Assert.assertFalse(PathUtils.leavesRepositoryRoot("..foo/Foo.java"));
+    }
+
+    @Test
+    public void testPathOutsideRepositoryRoot() throws Exception {
+        Assert.assertTrue(PathUtils.leavesRepositoryRoot("../other-repository/Foo.java"));
+        Assert.assertTrue(PathUtils.leavesRepositoryRoot("..\\other-repository\\Foo.java"));
+        Assert.assertTrue(PathUtils.leavesRepositoryRoot("../../Foo.java"));
+        Assert.assertTrue(PathUtils.leavesRepositoryRoot(".."));
+        // conservative: a ".." segment anywhere makes the plugin fall back to the absolute path
+        Assert.assertTrue(PathUtils.leavesRepositoryRoot("src/../main/Foo.java"));
+    }
+}


### PR DESCRIPTION
`PathUtils.getRelativeOrAbsolutePath()` is supposed to fall back to the absolute path for files which are not below the repository root, but the check only looked for a separator followed by `..`:

```java
if (relativePath == null || relativePath.contains(File.separator + "..")) {
```

The common case — a path that *starts* with `../` — does not contain `/..`, so it slipped through: `../other-repository/Foo.java` was treated as a path inside the Gerrit project and handed to Gerrit as a comment path and for marking a file as reviewed. Only `../..` or deeper was caught.

### Change

* new `leavesRepositoryRoot()` helper which inspects every path segment (after normalizing to `/`, so it works for both separators)
* conservative: any `..` segment makes the plugin fall back to the absolute path
* new `PathUtilsTest` covering paths inside and outside the root, with both separators

### Verification

`./gradlew test` — 22 tests including the new `PathUtilsTest`, all passing. The `instrumentCode` task cannot resolve its ant dependency in this sandbox and was skipped; it fails the same way on an unmodified checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR)_