### PR TITLE
Do not block the EDT while loading more changes

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/LoadChangesProxy.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/LoadChangesProxy.java
@@ -24,8 +24,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.util.Consumer;
 
 import java.util.List;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * @author Thomas Forrer
@@ -39,7 +38,7 @@ public class LoadChangesProxy {
     private String sortkey;
     private boolean hasMore = true;
     private final List<ChangeInfo> changes = Lists.newArrayList();
-    private final Lock lock = new ReentrantLock();
+    private final AtomicBoolean loading = new AtomicBoolean(false);
 
     public LoadChangesProxy(Changes.QueryRequest queryRequest,
                             GerritUtil gerritUtil,
@@ -50,19 +49,25 @@ public class LoadChangesProxy {
     }
 
     /**
-     * Load the next page of changes into the provided consumer
+     * Load the next page of changes into the provided consumer.
+     *
+     * Loading is asynchronous and this is called from the event dispatch thread (scrolling the change
+     * list), so a load which is already running must never be waited for: the result is handled on the
+     * event dispatch thread as well, which would deadlock. Such a call is skipped instead.
      */
     public void getNextPage(final Consumer<List<ChangeInfo>> consumer) {
-        if (hasMore) {
-            lock.lock();
-            Changes.QueryRequest myRequest = queryRequest.withLimit(PAGE_SIZE).withStart(changes.size());
-            // remove sortkey handling once we drop Gerrit < 2.9 support
-            if (sortkey != null) {
-                myRequest.withSortkey(sortkey);
-            }
-            Consumer<List<ChangeInfo>> myConsumer = new Consumer<List<ChangeInfo>>() {
-                @Override
-                public void consume(List<ChangeInfo> changeInfos) {
+        if (!hasMore || !loading.compareAndSet(false, true)) {
+            return;
+        }
+        Changes.QueryRequest myRequest = queryRequest.withLimit(PAGE_SIZE).withStart(changes.size());
+        // remove sortkey handling once we drop Gerrit < 2.9 support
+        if (sortkey != null) {
+            myRequest.withSortkey(sortkey);
+        }
+        Consumer<List<ChangeInfo>> myConsumer = new Consumer<List<ChangeInfo>>() {
+            @Override
+            public void consume(List<ChangeInfo> changeInfos) {
+                try {
                     if (changeInfos != null && !changeInfos.isEmpty()) {
                         ChangeInfo lastChangeInfo = Iterables.getLast(changeInfos);
                         hasMore = lastChangeInfo._moreChanges != null && lastChangeInfo._moreChanges;
@@ -72,10 +77,11 @@ public class LoadChangesProxy {
                         hasMore = false;
                     }
                     consumer.consume(changeInfos);
-                    lock.unlock();
+                } finally {
+                    loading.set(false);
                 }
-            };
-            gerritUtil.getChanges(myRequest, project, myConsumer);
-        }
+            }
+        };
+        gerritUtil.getChanges(myRequest, project, myConsumer);
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritChangeListPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritChangeListPanel.java
@@ -84,7 +84,6 @@ public class GerritChangeListPanel extends JPanel implements Consumer<LoadChange
 
     private Project project;
 
-    private volatile boolean loadingMoreChanges = false;
     private final JScrollPane scrollPane;
 
     public GerritChangeListPanel(Project project) {
@@ -107,20 +106,16 @@ public class GerritChangeListPanel extends JPanel implements Consumer<LoadChange
         scrollPane.getVerticalScrollBar().addAdjustmentListener(new AdjustmentListener() {
             @Override
             public void adjustmentValueChanged(AdjustmentEvent e) {
-                if (!loadingMoreChanges && loadChangesProxy != null) {
-                    loadingMoreChanges = true;
-                    try {
-                        int lowerEnd = e.getAdjustable().getVisibleAmount() + e.getAdjustable().getValue();
-                        if (lowerEnd == e.getAdjustable().getMaximum()) {
-                            loadChangesProxy.getNextPage(new Consumer<List<ChangeInfo>>() {
-                                @Override
-                                public void consume(List<ChangeInfo> changeInfos) {
-                                    addChanges(changeInfos);
-                                }
-                            });
-                        }
-                    } finally {
-                        loadingMoreChanges = false;
+                if (loadChangesProxy != null) {
+                    int lowerEnd = e.getAdjustable().getVisibleAmount() + e.getAdjustable().getValue();
+                    if (lowerEnd == e.getAdjustable().getMaximum()) {
+                        // a load which is already running is skipped by the proxy
+                        loadChangesProxy.getNextPage(new Consumer<List<ChangeInfo>>() {
+                            @Override
+                            public void consume(List<ChangeInfo> changeInfos) {
+                                addChanges(changeInfos);
+                            }
+                        });
                     }
                 }
             }


### PR DESCRIPTION
`LoadChangesProxy.getNextPage()` took a `ReentrantLock` for the whole asynchronous load and released it inside the result callback. That callback is dispatched to the EDT (`GerritUtil.accessGerrit()` → `invokeLater`), while `getNextPage()` itself is called *from* the EDT when the change list is scrolled to the bottom. A second scroll event therefore blocked the EDT on a lock that can only be released by the EDT — a deadlock that freezes the IDE. The lock was also never released when the callback was not invoked at all (project disposed, or an exception on the way to it), which wedges paging permanently.

The guard in `GerritChangeListPanel` that was meant to prevent the concurrent call did not work:

```java
loadingMoreChanges = true;
try {
    ... loadChangesProxy.getNextPage(...);   // asynchronous
} finally {
    loadingMoreChanges = false;             // runs immediately, long before the load finishes
}
```

It was also set even when the scroll position did not trigger a load at all.

### Change

* `LoadChangesProxy` guards the load itself with an `AtomicBoolean`: a call while a page is being loaded is **skipped**, never waited for, and the guard is released in a `finally` block so a throwing consumer cannot wedge it
* the broken flag in `GerritChangeListPanel` is removed in favour of that guard

With this, the worst case of a lost callback is that paging stops, instead of a frozen UI.

https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR)_