### PR TITLE
Fix error logged when push target branch is temporarily invalid

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushTargetPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushTargetPanel.java
@@ -35,10 +35,23 @@ import java.lang.reflect.Field;
 public class GerritPushTargetPanel extends GitPushTargetPanel {
 
     private static final Logger LOG = Logger.getInstance(GerritPushTargetPanel.class);
+
     private String branch;
+    private Field errorField;
+    private String platformError;
 
     public GerritPushTargetPanel(@NotNull GitPushSupport support, @NotNull GitRepository repository, @Nullable GitPushTarget defaultTarget, GerritPushOptionsPanel gerritPushOptionsPanel) {
         super(support, repository, defaultTarget);
+
+        try {
+            errorField = getField("myError");
+            // an error which the IDE has set itself (e.g. for a detached head); it must not be overwritten
+            platformError = (String) errorField.get(this);
+        } catch (NoSuchFieldException e) {
+            LOG.warn("Push target error field not available; invalid branch names cannot be marked", e);
+        } catch (IllegalAccessException e) {
+            LOG.warn("Push target error field not accessible; invalid branch names cannot be marked", e);
+        }
 
         String initialBranch = null;
         if (defaultTarget != null) {
@@ -105,23 +118,38 @@ public class GerritPushTargetPanel extends GitPushTargetPanel {
     }
 
     private void updateBranchTextField(Runnable myFireOnChangeAction) {
-        if (branch == null) {
-            // no valid value available (yet); keep the last valid one instead of writing something which the IDE
-            // would not be able to parse (see setBranch)
-            return;
-        }
         try {
-            Field myTargetEditorField = getField("myTargetEditor");
-            PushTargetTextField myTargetEditor = (PushTargetTextField) myTargetEditorField.get(this);
-            myTargetEditor.setText(branch);
+            if (branch != null) {
+                Field myTargetEditorField = getField("myTargetEditor");
+                PushTargetTextField myTargetEditor = (PushTargetTextField) myTargetEditorField.get(this);
+                myTargetEditor.setText(branch);
 
-            fireOnChange();
+                fireOnChange();
+            }
 
+            // also run it for an invalid branch name: it repaints the push dialog entry, which then shows the error
+            // set by setBranch instead of a push target which would not be used
             myFireOnChangeAction.run();
         } catch (NoSuchFieldException e) {
             LOG.error(e);
         } catch (IllegalAccessException e) {
             LOG.error(e);
+        }
+    }
+
+    /**
+     * Marks the push target as invalid, or as valid again for a {@code null} error. As long as an error is set, the
+     * IDE does not build a push target out of the text field content and the push dialog shows the error instead of
+     * a branch name.
+     */
+    private void setError(String error) {
+        if (errorField == null || platformError != null) {
+            return;
+        }
+        try {
+            errorField.set(this, error);
+        } catch (IllegalAccessException e) {
+            LOG.warn("Cannot update push target error", e);
         }
     }
 
@@ -132,14 +160,17 @@ public class GerritPushTargetPanel extends GitPushTargetPanel {
     }
 
     public void setBranch(String branch) {
-        if (branch == null) {
-            this.branch = null;
+        String trimmedBranch = branch == null ? "" : branch.trim();
+        if (GitRefNameValidator.getInstance().checkInput(trimmedBranch)) {
+            this.branch = trimmedBranch;
+            setError(null);
             return;
         }
-        String trimmedBranch = branch.trim();
         // Values which are no valid ref names must not be set: the IDE rejects them when it builds the push target
         // out of the text field content, which makes it log an error. Such values occur regularly while the user is
-        // still typing a branch name (e.g. "refs/for/release/" on the way to "refs/for/release/1.0").
-        this.branch = GitRefNameValidator.getInstance().checkInput(trimmedBranch) ? trimmedBranch : null;
+        // still typing a branch name (e.g. "refs/for/release/" on the way to "refs/for/release/1.0"). Mark the push
+        // target as invalid instead of leaving a branch name behind which would not be the one pushed to.
+        this.branch = null;
+        setError("Invalid destination branch name: " + trimmedBranch);
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushTargetPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushTargetPanel.java
@@ -104,6 +104,12 @@ public class GerritPushTargetPanel extends GitPushTargetPanel {
     }
 
     private void updateBranchTextField(Runnable myFireOnChangeAction) {
+        if (branch == null) {
+            // "branch" is only set to null for intermediate states which cannot be pushed (e.g. while the user is
+            // still typing a branch name like "release/"). Writing such a value into the push target field would
+            // make the IDE fail to parse the push target and log an error, so the last valid value is kept instead.
+            return;
+        }
         try {
             Field myTargetEditorField = getField("myTargetEditor");
             PushTargetTextField myTargetEditor = (PushTargetTextField) myTargetEditorField.get(this);
@@ -126,10 +132,15 @@ public class GerritPushTargetPanel extends GitPushTargetPanel {
     }
 
     public void setBranch(String branch) {
-        if (branch == null || branch.isEmpty() || branch.endsWith("/")) {
+        if (branch == null) {
             this.branch = null;
             return;
         }
-        this.branch = branch.trim();
+        String trimmedBranch = branch.trim();
+        if (trimmedBranch.isEmpty() || trimmedBranch.endsWith("/")) {
+            this.branch = null;
+            return;
+        }
+        this.branch = trimmedBranch;
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushTargetPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushTargetPanel.java
@@ -26,6 +26,7 @@ import git4idea.push.GitPushSupport;
 import git4idea.push.GitPushTarget;
 import git4idea.push.GitPushTargetPanel;
 import git4idea.repo.GitRepository;
+import git4idea.validators.GitRefNameValidator;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -105,9 +106,8 @@ public class GerritPushTargetPanel extends GitPushTargetPanel {
 
     private void updateBranchTextField(Runnable myFireOnChangeAction) {
         if (branch == null) {
-            // "branch" is only set to null for intermediate states which cannot be pushed (e.g. while the user is
-            // still typing a branch name like "release/"). Writing such a value into the push target field would
-            // make the IDE fail to parse the push target and log an error, so the last valid value is kept instead.
+            // no valid value available (yet); keep the last valid one instead of writing something which the IDE
+            // would not be able to parse (see setBranch)
             return;
         }
         try {
@@ -137,10 +137,9 @@ public class GerritPushTargetPanel extends GitPushTargetPanel {
             return;
         }
         String trimmedBranch = branch.trim();
-        if (trimmedBranch.isEmpty() || trimmedBranch.endsWith("/")) {
-            this.branch = null;
-            return;
-        }
-        this.branch = trimmedBranch;
+        // Values which are no valid ref names must not be set: the IDE rejects them when it builds the push target
+        // out of the text field content, which makes it log an error. Such values occur regularly while the user is
+        // still typing a branch name (e.g. "refs/for/release/" on the way to "refs/for/release/1.0").
+        this.branch = GitRefNameValidator.getInstance().checkInput(trimmedBranch) ? trimmedBranch : null;
     }
 }


### PR DESCRIPTION
Fixes the exception report:

```
java.text.ParseException: Invalid destination branch name:
	at git4idea.push.GitPushTarget.parse(GitPushTarget.java:104)
	at git4idea.push.GitPushTargetPanel.fireOnChange(GitPushTargetPanel.java:423)
	at com.urswolfer.intellij.plugin.gerrit.push.GerritPushTargetPanel.updateBranchTextField(GerritPushTargetPanel.java:112)
	at com.urswolfer.intellij.plugin.gerrit.push.GerritPushTargetPanel.updateBranch(GerritPushTargetPanel.java:96)
	at com.urswolfer.intellij.plugin.gerrit.push.GerritPushExtensionPanel.updateDestinationBranch(GerritPushExtensionPanel.java:354)
	at com.urswolfer.intellij.plugin.gerrit.push.GerritPushExtensionPanel$ChangeTextActionListener.handleChange(GerritPushExtensionPanel.java:396)
	at com.urswolfer.intellij.plugin.gerrit.push.GerritPushExtensionPanel$ChangeTextActionListener.insertUpdate(GerritPushExtensionPanel.java:382)
```

with the logged message `Invalid remote name shouldn't be allowed. [origin, ]` — the second element is the push target text, which was empty.

### Cause

1. The user types into a push dialog text field → `ChangeTextActionListener.insertUpdate` → `updateDestinationBranch()` → `GerritPushTargetPanel.updateBranch()`.
2. While a branch name containing a slash is half-typed (`release/` on the way to `release/1.0`), `getRef()` builds `refs/for/release/`.
3. `setBranch()` rejects values ending in `/` and leaves `branch` at `null`.
4. `updateBranchTextField()` nevertheless called `myTargetEditor.setText(branch)` with that `null`, emptying the field, and then `fireOnChange()`. `GitRefNameValidator.checkInput("")` is `false` (`isEmptyOrSpaces`), so `GitPushTarget.parse` throws `ParseException` and the platform logs it as an error.

So this is not a failing push — a transient typing state was written into the platform's target field.

### Fix

* `setBranch()` validates with `GitRefNameValidator`, the validator `GitPushTarget.parse` itself uses, so every value the IDE would reject is recognized — not only blank names and a trailing `/`, but also `refs/for/release.`, `a..b`, names containing a space and `.lock` endings.
* Such a value is no longer written into the push target field. Instead the push target is marked as invalid through the panel's error, which makes the IDE show the message in the push dialog entry, report it when the target field is validated, and skip building a push target out of the text field content — the step which logged the error. The error is cleared as soon as the settings produce a valid ref again; an error the IDE set itself (detached head, empty repository, nothing to push to) is never overwritten.

Checked against the validator of the SDK this plugin builds against that the refs this dialog produces stay valid: `refs/for/release/1.0`, `%topic=...`, `hashtag=...`, `r=user@example.com`, percent-encoded patch set descriptions, `wip`/`private`.

https://claude.ai/code/session_011W6EKRnvrutPL29kAgPdWW


---
_Generated by [Claude Code](https://claude.ai/code/session_011W6EKRnvrutPL29kAgPdWW)_