### PR TITLE
Encode the percent sign of a filter query only once

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/FulltextFilter.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/FulltextFilter.java
@@ -58,13 +58,14 @@ public class FulltextFilter extends AbstractChangesFilter {
      */
     public static String specialEncodeFulltextQuery(String query) {
         return query
+                // has to be encoded first, it would otherwise encode the percent signs introduced below again
+                .replace("%", "%25")
                 .replace("{", "%7B")
                 .replace("}", "%7D")
                 .replace("+", "%2B")
                 .replace(' ', '+')
                 .replace("\"", "%22")
                 .replace("\\", "%5C")
-                .replace("%", "%25")
                 .replace("<", "%3C")
                 .replace(">", "%3E")
                 .replace("^", "%5E");

--- a/src/test/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/FulltextFilterTest.java
+++ b/src/test/java/com/urswolfer/intellij/plugin/gerrit/ui/filter/FulltextFilterTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.urswolfer.intellij.plugin.gerrit.ui.filter;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class FulltextFilterTest {
+
+    @Test
+    public void testEncodeSpecialCharacters() throws Exception {
+        Assert.assertEquals(FulltextFilter.specialEncodeFulltextQuery("{merged:1day}"), "%7Bmerged:1day%7D");
+        Assert.assertEquals(FulltextFilter.specialEncodeFulltextQuery("a+b"), "a%2Bb");
+        Assert.assertEquals(FulltextFilter.specialEncodeFulltextQuery("message:\"fix\""), "message:%22fix%22");
+        Assert.assertEquals(FulltextFilter.specialEncodeFulltextQuery("a\\b"), "a%5Cb");
+        Assert.assertEquals(FulltextFilter.specialEncodeFulltextQuery("a<b>c^d"), "a%3Cb%3Ec%5Ed");
+    }
+
+    @Test
+    public void testEncodePercentOnlyOnce() throws Exception {
+        Assert.assertEquals(FulltextFilter.specialEncodeFulltextQuery("50%"), "50%25");
+        // the percent signs of the encoded characters must not be encoded again
+        Assert.assertEquals(FulltextFilter.specialEncodeFulltextQuery("100% {done}"), "100%25+%7Bdone%7D");
+    }
+
+    @Test
+    public void testEncodeSpaceAsPlus() throws Exception {
+        Assert.assertEquals(FulltextFilter.specialEncodeFulltextQuery("owner:self status:open"), "owner:self+status:open");
+    }
+}


### PR DESCRIPTION
`FulltextFilter.specialEncodeFulltextQuery()` encoded `%` as the **last** step, after five other replacements had already introduced percent signs. Those were encoded a second time:

| typed in the filter | sent to Gerrit | Gerrit sees |
|---|---|---|
| `{merged:1day}` | `%257Bmerged:1day%257D` | `%7Bmerged:1day%7D` |
| `fix "quoted" bug` | `fix+%2522quoted%2522+bug` | `fix+%22quoted%22+bug` |
| `a+b` | `a%252Bb` | `a%2Bb` |

So any filter containing `{`, `}`, `+`, `"` or `\` silently matched nothing (`<`, `>` and `^` were fine — they are replaced after the `%` step). The same helper is used for the user filters (Owner, Reviewer, Assignee, Attention).

### Change

* encode `%` first — the only order in which the escape character itself can be handled
* new `FulltextFilterTest` covering the special characters, the percent sign and the space-as-plus encoding

https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR)_