### PR TITLE
Escape comment text before it is rendered as HTML

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/TextToHtml.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/TextToHtml.java
@@ -29,11 +29,14 @@ public final class TextToHtml {
      * Converts plain text formatted with wiki-like syntax to HTML.
      */
     public static String textToHtml(String text) {
-        if (!text.contains("\n")) {
-            return text;
+        // SafeHtml handles the text it is given as HTML which is escaped already. A comment or a change message
+        // is plain text, so it needs to be escaped first; otherwise it is rendered as markup (and the quote
+        // handling of wikify(), which looks for an escaped "&gt; ", never matches).
+        String escapedText = new SafeHtmlBuilder().append(text).toSafeHtml().asString();
+        if (!escapedText.contains("\n")) {
+            return SafeHtmlBuilder.asis(escapedText).linkify().asString();
         }
-        text = SafeHtmlBuilder.asis(text).wikify().asString();
-        text = text.replace("</p><p>", "</p><br/><p>"); // otherwise paragraph breaks are not visible in IntelliJ...
-        return text;
+        String html = SafeHtmlBuilder.asis(escapedText).wikify().asString();
+        return html.replace("</p><p>", "</p><br/><p>"); // otherwise paragraph breaks are not visible in IntelliJ...
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/safehtml/SafeHtmlBuilder.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/safehtml/SafeHtmlBuilder.java
@@ -19,7 +19,8 @@ package com.urswolfer.intellij.plugin.gerrit.util.safehtml;
 /** Safely constructs a {@link SafeHtml}, escaping user provided content. */
 @SuppressWarnings("serial")
 public class SafeHtmlBuilder extends SafeHtml {
-  private static final Impl impl = new ClientImpl();
+  // ClientImpl escapes with a GWT native method, which is not available here: this code runs in a JVM
+  private static final Impl impl = new ServerImpl();
 
   private final BufferDirect dBuf;
   private Buffer cb;

--- a/src/test/java/com/urswolfer/intellij/plugin/gerrit/util/TextToHtmlTest.java
+++ b/src/test/java/com/urswolfer/intellij/plugin/gerrit/util/TextToHtmlTest.java
@@ -34,6 +34,12 @@ public class TextToHtmlTest {
                         "<p>Test</p><ul><li>list 1</li><li>list 2</li><li>list 3</li></ul><p>End line</p>"},
                 { "Test\n\n  code line 1\n  code line 2\n  code line 3\n    code line 4 more indented\n\nEnd line",
                         "<p>Test</p><pre>  code line 1<br />  code line 2<br />  code line 3<br />    code line 4 more indented<br /></pre><p>End line</p>"},
+                { "Use List<String> & Map<K,V> here", "Use List&lt;String&gt; &amp; Map&lt;K,V&gt; here"},
+                { "Use List<String> here\nand Map<K,V> there", "<p>Use List&lt;String&gt; here\nand Map&lt;K,V&gt; there</p>"},
+                { "> quoted previous comment\n> second line\n\nmy reply",
+                        "<blockquote>quoted previous comment\nsecond line</blockquote><p>my reply</p>"},
+                { "see http://example.com/x for details",
+                        "see <a href=\"http://example.com/x\" target=\"_blank\" rel=\"nofollow\">http://example.com/x</a> for details"},
         };
     }
 


### PR DESCRIPTION
`SafeHtml.asis()` means "this string is already escaped HTML", but `TextToHtml.textToHtml()` handed it raw comment and change message text, so nothing was ever escaped:

```
IN : Use List<String> & Map<K,V> here
OUT: Use List<String> & Map<K,V> here
```

That string goes into the comment gutter tooltip, the change details panel and the comment preview, all of which render HTML — Swing silently swallows everything that looks like a tag. For the same reason `SafeHtml.isQuote()`, which tests for an escaped `&gt; `, never matched, so quoted text was never rendered as a blockquote.

### Change

* escape the text before handing it to `SafeHtml`
* single line text is now run through `linkify()` instead of being returned unprocessed, so its URLs become links just like in multi line text
* `SafeHtmlBuilder.append(String)` escaped through `ClientImpl`, whose `escape` is a GWT **native** method — calling it in the IDE throws `UnsatisfiedLinkError` (verified by running it). Switched the implementation to `ServerImpl`, the one meant for a JVM; both escape the same five characters.

After the change:

```
IN : Use List<String> & Map<K,V> here
OUT: Use List&lt;String&gt; &amp; Map&lt;K,V&gt; here

IN : > quoted previous comment\n> second line\n\nmy reply
OUT: <blockquote>quoted previous comment\nsecond line</blockquote><p>my reply</p>

IN : see http://example.com/x for details
OUT: see <a href="http://example.com/x" target="_blank" rel="nofollow">http://example.com/x</a> for details
```

https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR)_