### PR TITLE
Load the comment counts of a change in background

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritCommentCountChangeNodeDecorator.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritCommentCountChangeNodeDecorator.java
@@ -26,6 +26,7 @@ import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.vcs.changes.Change;
 import com.intellij.openapi.vcs.changes.ContentRevision;
 import com.intellij.ui.SimpleColoredComponent;
@@ -48,6 +49,8 @@ public class GerritCommentCountChangeNodeDecorator implements GerritChangeNodeDe
     private final GerritSettings gerritSettings = GerritSettings.getInstance();
 
     private final SelectedRevisions selectedRevisions;
+    private final Project project;
+    private final Disposable parent;
 
     private ChangeInfo selectedChange;
 
@@ -56,9 +59,14 @@ public class GerritCommentCountChangeNodeDecorator implements GerritChangeNodeDe
     private Map<String, List<CommentInfo>> drafts = Collections.emptyMap();
     private Set<String> reviewed = Collections.emptySet();
 
+    /** Incremented on the event dispatch thread for every load, so that a load in progress can tell it is obsolete. */
+    private volatile long loadGeneration;
+
     private Runnable dataLoadedCallback;
 
     public GerritCommentCountChangeNodeDecorator(Project project, Disposable parent) {
+        this.project = project;
+        this.parent = parent;
         this.selectedRevisions = SelectedRevisions.getInstance(project);
         this.selectedRevisions.addListener(new SelectedRevisions.Listener() {
             @Override
@@ -101,12 +109,17 @@ public class GerritCommentCountChangeNodeDecorator implements GerritChangeNodeDe
     }
 
     /**
-     * Loads the comments, drafts and reviewed files of the selected change in the background.
+     * Loads the comments, drafts and reviewed files of the selected change in the background. Every load gets a
+     * generation which is checked before each request and before the result is published, so that a load which has
+     * been superseded (another change or another revision of it got selected) stops instead of overwriting newer
+     * data, and one which outlived the tool window does not touch it any more.
      */
     private void loadData() {
         comments = Collections.emptyMap();
         drafts = Collections.emptyMap();
         reviewed = Collections.emptySet();
+
+        final long generation = ++loadGeneration; // only written here, and this runs on the event dispatch thread
 
         final ChangeInfo change = selectedChange;
         if (change == null) {
@@ -121,13 +134,22 @@ public class GerritCommentCountChangeNodeDecorator implements GerritChangeNodeDe
         ApplicationManager.getApplication().executeOnPooledThread(new Runnable() {
             @Override
             public void run() {
+                if (isObsolete(generation)) {
+                    return;
+                }
                 final Map<String, List<CommentInfo>> loadedComments = loadComments(change, revisionId);
+                if (isObsolete(generation)) {
+                    return;
+                }
                 final Map<String, List<CommentInfo>> loadedDrafts = loadDrafts(change, revisionId);
+                if (isObsolete(generation)) {
+                    return;
+                }
                 final Set<String> loadedReviewed = loadReviewed(change, revisionId);
                 ApplicationManager.getApplication().invokeLater(new Runnable() {
                     @Override
                     public void run() {
-                        if (change != selectedChange) { // another change has been selected in the meantime
+                        if (isObsolete(generation)) {
                             return;
                         }
                         comments = loadedComments;
@@ -140,6 +162,10 @@ public class GerritCommentCountChangeNodeDecorator implements GerritChangeNodeDe
                 });
             }
         });
+    }
+
+    private boolean isObsolete(long generation) {
+        return generation != loadGeneration || project.isDisposed() || Disposer.isDisposed(parent);
     }
 
     private String getAffectedFilePath(Change change) {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritCommentCountChangeNodeDecorator.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritCommentCountChangeNodeDecorator.java
@@ -18,13 +18,12 @@ package com.urswolfer.intellij.plugin.gerrit.ui;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import com.google.common.collect.Lists;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.google.gerrit.extensions.common.CommentInfo;
 import com.google.gerrit.extensions.restapi.RestApiException;
 import com.intellij.openapi.Disposable;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vcs.changes.Change;
@@ -51,9 +50,13 @@ public class GerritCommentCountChangeNodeDecorator implements GerritChangeNodeDe
     private final SelectedRevisions selectedRevisions;
 
     private ChangeInfo selectedChange;
-    private Supplier<Map<String, List<CommentInfo>>> comments = setupCommentsSupplier();
-    private Supplier<Map<String, List<CommentInfo>>> drafts = setupDraftsSupplier();
-    private Supplier<Set<String>> reviewed = setupReviewedSupplier();
+
+    /** Loaded by {@link #loadData()}; only read and written on the event dispatch thread. */
+    private Map<String, List<CommentInfo>> comments = Collections.emptyMap();
+    private Map<String, List<CommentInfo>> drafts = Collections.emptyMap();
+    private Set<String> reviewed = Collections.emptySet();
+
+    private Runnable dataLoadedCallback;
 
     public GerritCommentCountChangeNodeDecorator(Project project, Disposable parent) {
         this.selectedRevisions = SelectedRevisions.getInstance(project);
@@ -61,18 +64,24 @@ public class GerritCommentCountChangeNodeDecorator implements GerritChangeNodeDe
             @Override
             public void selectedRevisionChanged(String changeId) {
                 if (changeId != null && selectedChange != null && selectedChange.id.equals(changeId)) {
-                    refreshSuppliers();
+                    loadData();
                 }
             }
         }, parent);
     }
 
-    private void refreshSuppliers() {
-        comments = setupCommentsSupplier();
-        drafts = setupDraftsSupplier();
-        reviewed = setupReviewedSupplier();
+    /**
+     * @param dataLoadedCallback executed on the event dispatch thread once the data of the selected change has been
+     *                           loaded, so that the nodes displaying it can be repainted
+     */
+    public void setDataLoadedCallback(Runnable dataLoadedCallback) {
+        this.dataLoadedCallback = dataLoadedCallback;
     }
 
+    /**
+     * Called while a change node gets painted, so it must not perform any remote calls: it displays what
+     * {@link #loadData()} has loaded so far.
+     */
     @Override
     public void decorate(Project project, Change change, SimpleColoredComponent component, ChangeInfo selectedChange) {
         String affectedFilePath = getAffectedFilePath(change);
@@ -88,7 +97,49 @@ public class GerritCommentCountChangeNodeDecorator implements GerritChangeNodeDe
     @Override
     public void onChangeSelected(Project project, ChangeInfo selectedChange) {
         this.selectedChange = selectedChange;
-        refreshSuppliers();
+        loadData();
+    }
+
+    /**
+     * Loads the comments, drafts and reviewed files of the selected change in the background.
+     */
+    private void loadData() {
+        comments = Collections.emptyMap();
+        drafts = Collections.emptyMap();
+        reviewed = Collections.emptySet();
+
+        final ChangeInfo change = selectedChange;
+        if (change == null) {
+            return;
+        }
+        final String revisionId = selectedRevisions.get(change);
+        if (revisionId == null) {
+            return;
+        }
+        gerritSettings.preloadPassword(); // the password cannot be read from the background thread below
+
+        ApplicationManager.getApplication().executeOnPooledThread(new Runnable() {
+            @Override
+            public void run() {
+                final Map<String, List<CommentInfo>> loadedComments = loadComments(change, revisionId);
+                final Map<String, List<CommentInfo>> loadedDrafts = loadDrafts(change, revisionId);
+                final Set<String> loadedReviewed = loadReviewed(change, revisionId);
+                ApplicationManager.getApplication().invokeLater(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (change != selectedChange) { // another change has been selected in the meantime
+                            return;
+                        }
+                        comments = loadedComments;
+                        drafts = loadedDrafts;
+                        reviewed = loadedReviewed;
+                        if (dataLoadedCallback != null) {
+                            dataLoadedCallback.run();
+                        }
+                    }
+                });
+            }
+        });
     }
 
     private String getAffectedFilePath(Change change) {
@@ -108,19 +159,17 @@ public class GerritCommentCountChangeNodeDecorator implements GerritChangeNodeDe
         fileName = PathUtils.ensureSlashSeparators(fileName);
         List<String> parts = Lists.newArrayList();
 
-        Map<String, List<CommentInfo>> commentsMap = comments.get();
-        List<CommentInfo> commentsForFile = commentsMap.get(fileName);
+        List<CommentInfo> commentsForFile = comments.get(fileName);
         if (commentsForFile != null) {
             parts.add(String.format("%s comment%s", commentsForFile.size(), commentsForFile.size() == 1 ? "" : "s"));
         }
 
-        Map<String, List<CommentInfo>> draftsMap = drafts.get();
-        List<CommentInfo> draftsForFile = draftsMap.get(fileName);
+        List<CommentInfo> draftsForFile = drafts.get(fileName);
         if (draftsForFile != null) {
             parts.add(String.format("%s draft%s", draftsForFile.size(), draftsForFile.size() == 1 ? "" : "s"));
         }
 
-        if (reviewed.get().contains(fileName)) {
+        if (reviewed.contains(fileName)) {
             parts.add("reviewed");
         }
 
@@ -131,64 +180,45 @@ public class GerritCommentCountChangeNodeDecorator implements GerritChangeNodeDe
         return PathUtils.getRelativeOrAbsolutePath(project, absoluteFilePath, selectedChange.project);
     }
 
-    private Supplier<Map<String, List<CommentInfo>>> setupCommentsSupplier() {
-        return Suppliers.memoize(new Supplier<Map<String, List<CommentInfo>>>() {
-            @Override
-            public Map<String, List<CommentInfo>> get() {
-                try {
-                    return GerritApiProvider.getInstance().get().changes()
-                            .id(selectedChange.id)
-                            .revision(getSelectedRevisionId())
-                            .comments();
-                } catch (RestApiException e) {
-                    LOG.warn(e);
-                    return Collections.emptyMap();
-                }
-            }
-        });
+    private Map<String, List<CommentInfo>> loadComments(ChangeInfo change, String revisionId) {
+        try {
+            return GerritApiProvider.getInstance().get().changes()
+                    .id(change.id)
+                    .revision(revisionId)
+                    .comments();
+        } catch (RestApiException e) {
+            LOG.warn(e);
+            return Collections.emptyMap();
+        }
     }
 
-    private Supplier<Map<String, List<CommentInfo>>> setupDraftsSupplier() {
-        return Suppliers.memoize(new Supplier<Map<String, List<CommentInfo>>>() {
-            @Override
-            public Map<String, List<CommentInfo>> get() {
-                if (!gerritSettings.isLoginAndPasswordAvailable()) {
-                    return Collections.emptyMap();
-                }
-                try {
-                    return GerritApiProvider.getInstance().get().changes()
-                            .id(selectedChange.id)
-                            .revision(getSelectedRevisionId())
-                            .drafts();
-                } catch (RestApiException e) {
-                    LOG.warn(e);
-                    return Collections.emptyMap();
-                }
-            }
-        });
+    private Map<String, List<CommentInfo>> loadDrafts(ChangeInfo change, String revisionId) {
+        if (!gerritSettings.isLoginAndPasswordAvailable()) {
+            return Collections.emptyMap();
+        }
+        try {
+            return GerritApiProvider.getInstance().get().changes()
+                    .id(change.id)
+                    .revision(revisionId)
+                    .drafts();
+        } catch (RestApiException e) {
+            LOG.warn(e);
+            return Collections.emptyMap();
+        }
     }
 
-    private Supplier<Set<String>> setupReviewedSupplier() {
-        return Suppliers.memoize(new Supplier<Set<String>>() {
-            @Override
-            public Set<String> get() {
-                if (!gerritSettings.isLoginAndPasswordAvailable()) {
-                    return Collections.emptySet();
-                }
-                try {
-                    return GerritApiProvider.getInstance().get().changes()
-                            .id(selectedChange.id)
-                            .revision(getSelectedRevisionId())
-                            .reviewed();
-                } catch (RestApiException e) {
-                    LOG.warn(e);
-                    return Collections.emptySet();
-                }
-            }
-        });
-    }
-
-    private String getSelectedRevisionId() {
-        return selectedRevisions.get(selectedChange);
+    private Set<String> loadReviewed(ChangeInfo change, String revisionId) {
+        if (!gerritSettings.isLoginAndPasswordAvailable()) {
+            return Collections.emptySet();
+        }
+        try {
+            return GerritApiProvider.getInstance().get().changes()
+                    .id(change.id)
+                    .revision(revisionId)
+                    .reviewed();
+        } catch (RestApiException e) {
+            LOG.warn(e);
+            return Collections.emptySet();
+        }
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/RepositoryChangesBrowserProvider.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/RepositoryChangesBrowserProvider.java
@@ -102,6 +102,13 @@ public class RepositoryChangesBrowserProvider {
                 changesBrowser.setSelectedChange(changeInfo);
             }
         });
+        // the comment counts are loaded in background, the nodes displaying them have to be repainted afterwards
+        commentCountChangeNodeDecorator.setDataLoadedCallback(new Runnable() {
+            @Override
+            public void run() {
+                changesBrowser.getViewer().repaint();
+            }
+        });
         return changesBrowser;
     }
 


### PR DESCRIPTION
`GerritCommentCountChangeNodeDecorator` resolved three memoized suppliers inside `decorate()`:

```java
Map<String, List<CommentInfo>> commentsMap = comments.get();   // REST: .comments()
Map<String, List<CommentInfo>> draftsMap = drafts.get();       // REST: .drafts()
if (reviewed.get().contains(fileName)) { … }                   // REST: .reviewed()
```

`decorate()` is called by the renderer of the changes tree while it paints a node, i.e. on the event dispatch thread. Selecting a change therefore blocked the EDT with up to three REST round-trips; on a slow or unreachable Gerrit the IDE froze until they hit their timeout.

### Change

* the data is loaded in a pooled thread when a change (or another revision of it) is selected, published on the EDT and only then displayed; `decorate()` performs no remote calls at all any more
* the password is preloaded on the EDT before the background load, since `GerritSettings.getPassword()` refuses to read it from a background thread
* a result that arrives after another change has been selected is dropped
* `RepositoryChangesBrowserProvider` passes a callback that repaints the tree once the data is there, so the counts appear as soon as they have been loaded

https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR)_