### PR TITLE
Determine the newest revision by its patch set number

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/SelectedRevisions.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/SelectedRevisions.java
@@ -17,18 +17,19 @@
 package com.urswolfer.intellij.plugin.gerrit;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.components.Service;
 import com.intellij.openapi.project.Project;
 import com.intellij.util.EventDispatcher;
+import com.urswolfer.intellij.plugin.gerrit.util.RevisionInfos;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.VisibleForTesting;
 
+import java.util.Collections;
 import java.util.EventListener;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Class keeping record of all selected revisions by change.
@@ -65,15 +66,24 @@ public final class SelectedRevisions {
      */
     public String get(ChangeInfo changeInfo) {
         String currentRevision = changeInfo.currentRevision;
-        if (currentRevision == null && changeInfo.revisions != null) {
+        if (currentRevision == null) {
             // don't know why with some changes currentRevision is not set,
             // the revisions map however is usually populated
-            Set<String> revisionKeys = changeInfo.revisions.keySet();
-            if (!revisionKeys.isEmpty()) {
-                currentRevision = Iterables.getLast(revisionKeys);
-            }
+            currentRevision = getNewestRevision(changeInfo);
         }
         return get(changeInfo.id).or(Optional.fromNullable(currentRevision)).orNull();
+    }
+
+    /**
+     * @return the revision with the highest patch set number, or {@code null} if the change provides no revisions.
+     *         The revisions map has no defined order, so the newest revision cannot be taken from its last entry.
+     */
+    @VisibleForTesting
+    static String getNewestRevision(ChangeInfo changeInfo) {
+        if (changeInfo.revisions == null || changeInfo.revisions.isEmpty()) {
+            return null;
+        }
+        return Collections.max(changeInfo.revisions.entrySet(), RevisionInfos.MAP_ENTRY_COMPARATOR).getKey();
     }
 
     public void put(String changeId, String revisionHash) {

--- a/src/test/java/com/urswolfer/intellij/plugin/gerrit/SelectedRevisionsTest.java
+++ b/src/test/java/com/urswolfer/intellij/plugin/gerrit/SelectedRevisionsTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.urswolfer.intellij.plugin.gerrit;
+
+import com.google.gerrit.extensions.common.ChangeInfo;
+import com.google.gerrit.extensions.common.RevisionInfo;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.LinkedHashMap;
+
+public class SelectedRevisionsTest {
+
+    @Test
+    public void testNewestRevisionIsTheOneWithTheHighestPatchSetNumber() throws Exception {
+        ChangeInfo changeInfo = new ChangeInfo();
+        changeInfo.revisions = new LinkedHashMap<String, RevisionInfo>();
+        // the revisions map has no defined order; the last entry is not necessarily the newest revision
+        changeInfo.revisions.put("aaa", revision(2));
+        changeInfo.revisions.put("bbb", revision(3));
+        changeInfo.revisions.put("ccc", revision(1));
+
+        Assert.assertEquals(SelectedRevisions.getNewestRevision(changeInfo), "bbb");
+    }
+
+    @Test
+    public void testNoRevisions() throws Exception {
+        ChangeInfo withoutRevisions = new ChangeInfo();
+        Assert.assertNull(SelectedRevisions.getNewestRevision(withoutRevisions));
+
+        ChangeInfo withEmptyRevisions = new ChangeInfo();
+        withEmptyRevisions.revisions = new LinkedHashMap<String, RevisionInfo>();
+        Assert.assertNull(SelectedRevisions.getNewestRevision(withEmptyRevisions));
+    }
+
+    private static RevisionInfo revision(int number) {
+        RevisionInfo revisionInfo = new RevisionInfo();
+        revisionInfo._number = number;
+        return revisionInfo;
+    }
+}


### PR DESCRIPTION
When a change does not provide `currentRevision`, `SelectedRevisions.get(ChangeInfo)` fell back to the **last key** of the revisions map:

```java
Set<String> revisionKeys = changeInfo.revisions.keySet();
if (!revisionKeys.isEmpty()) {
    currentRevision = Iterables.getLast(revisionKeys);
}
```

That map is deserialized from JSON and has no defined order, so its last entry is not necessarily the newest patch set. Whenever it isn't, the plugin diffs, checks out, comments on and votes for an older patch set without any indication.

### Change

* take the revision with the highest `_number`, using the `RevisionInfos.MAP_ENTRY_COMPARATOR` the patch set column and the base revision popup already sort with
* the lookup moved into a package-visible `getNewestRevision()` so it can be tested without the project service
* new `SelectedRevisionsTest` feeding a map whose last entry is *not* the newest patch set

https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR)_