### PR TITLE
Close the CC row of the change details

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritChangeDetailsPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/GerritChangeDetailsPanel.java
@@ -194,11 +194,12 @@ public class GerritChangeDetailsPanel {
                     }
                     sb.append("</td></tr>");
                 }
-                if (ccAccounts != null) {
+                if (ccAccounts != null && !ccAccounts.isEmpty()) {
                     sb.append("<tr valign=\"top\"><td><i>").append("CC").append(":</i></td><td>");
                     for (ApprovalInfo approvalInfo : ccAccounts) {
                         sb.append("<b>").append(approvalInfo.name).append("</b>").append("<br/>");
                     }
+                    sb.append("</td></tr>");
                 }
             }
         }


### PR DESCRIPTION
In `GerritChangeDetailsPanel`, the table row listing the accounts in CC is opened with `<tr …><td>…</td><td>` but never closed, so everything that follows it — the comments of the change — ends up inside that cell.

### Change

* append the missing `</td></tr>`
* skip the row when there is nobody to list; it rendered as an empty "CC:" row whenever every reviewer had voted

https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR)_