### PR TITLE
Disable the submit action for changes which cannot be submitted

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/GerritUtil.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/GerritUtil.java
@@ -299,7 +299,8 @@ public final class GerritUtil {
                                 ListChangesOption.CHANGE_ACTIONS,
                                 ListChangesOption.CURRENT_ACTIONS,
                                 ListChangesOption.DETAILED_LABELS,
-                                ListChangesOption.LABELS
+                                ListChangesOption.LABELS,
+                                ListChangesOption.SUBMITTABLE
                             ));
                     return new LoadChangesProxy(queryRequest, GerritUtil.this, project);
             }
@@ -324,11 +325,12 @@ public final class GerritUtil {
                                 tryFallback = true;
                                 queryRequest.withStart(0); // remove start, trust that sortkey is set
                             }
-                            if (message.matches(".*Content:.*\"(CHANGE_ACTIONS|CURRENT_ACTIONS)\".*\"-o\".*")) {
+                            if (message.matches(".*Content:.*\"(CHANGE_ACTIONS|CURRENT_ACTIONS|SUBMITTABLE)\".*\"-o\".*")) {
                                 tryFallback = true;
                                 Set<ListChangesOption> options = queryRequest.getOptions();
                                 options.remove(ListChangesOption.CHANGE_ACTIONS);
                                 options.remove(ListChangesOption.CURRENT_ACTIONS);
+                                options.remove(ListChangesOption.SUBMITTABLE);
                                 queryRequest.withOptions(options);
                             }
                             if (tryFallback) {

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/SubmitAction.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/action/SubmitAction.java
@@ -40,13 +40,15 @@ public class SubmitAction extends AbstractLoggedInChangeAction {
     public void update(AnActionEvent e) {
         super.update(e);
         Optional<ChangeInfo> selectedChange = getSelectedChange(e);
-        if (selectedChange.isPresent() && isSubmittable(selectedChange.get())) {
+        if (selectedChange.isPresent() && !canSubmit(selectedChange.get())) {
             e.getPresentation().setEnabled(false);
         }
     }
 
-    private boolean isSubmittable(ChangeInfo selectedChange) {
-        return Boolean.FALSE.equals(selectedChange.submittable);
+    private boolean canSubmit(ChangeInfo selectedChange) {
+        // null if the Gerrit instance does not report it (it is only set when the query asks for SUBMITTABLE, and
+        // older instances do not know that option at all); assume the change can be submitted in that case
+        return !Boolean.FALSE.equals(selectedChange.submittable);
     }
 
     @Override


### PR DESCRIPTION
`SubmitAction.update()` disables the action for a change that cannot be submitted by reading `ChangeInfo.submittable`. Gerrit only fills that field when the query asks for `ListChangesOption.SUBMITTABLE`, and no query in the plugin did — so the field was always `null`, `Boolean.FALSE.equals(null)` was always `false`, and "Submit" stayed enabled for every change. The user found out that the change is not submittable from the error of the REST call.

### Change

* request `ListChangesOption.SUBMITTABLE` for the change list
* add it to the existing 400-fallback (next to `CHANGE_ACTIONS`/`CURRENT_ACTIONS`), so Gerrit instances which do not know the option keep working: the option is dropped and the query is retried
* the check now reads as what it does (`canSubmit`), and a change whose `submittable` is not reported at all stays enabled — the same "assume an older Gerrit instance" convention `AbandonAction`, `PublishAction` and `DeleteAction` use

https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR)_