### PR TITLE
Strip the ".git" extension only at the end of a url

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/UrlUtils.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/util/UrlUtils.java
@@ -25,6 +25,8 @@ import java.nio.charset.StandardCharsets;
  */
 public class UrlUtils {
 
+    private static final String GIT_EXTENSION = ".git";
+
     private UrlUtils() {}
 
     public static boolean urlHasSameHost(String url, String hostUrl) {
@@ -42,8 +44,16 @@ public class UrlUtils {
         return URI.create(gitConfigUrl);
     }
 
+    /**
+     * Removes the ".git" some repositories end their name with. Only at the end: any other occurrence belongs to a
+     * host or project name (e.g. "gerrit.gitlab.example.com" or "my.github-actions") and must be kept.
+     */
     public static String stripGitExtension(String url) {
-        return url.replace(".git", ""); // some repositories end their name with ".git"
+        String strippedUrl = url.endsWith("/") ? url.substring(0, url.length() - 1) : url;
+        if (strippedUrl.endsWith(GIT_EXTENSION)) {
+            return strippedUrl.substring(0, strippedUrl.length() - GIT_EXTENSION.length());
+        }
+        return url;
     }
 
     public static String encodePatchSetDescription(String text) {

--- a/src/test/java/com/urswolfer/intellij/plugin/gerrit/util/UrlUtilsTest.java
+++ b/src/test/java/com/urswolfer/intellij/plugin/gerrit/util/UrlUtilsTest.java
@@ -63,6 +63,27 @@ public class UrlUtilsTest {
     }
 
     @Test
+    public void testStripGitExtension() throws Exception {
+        Assert.assertEquals(UrlUtils.stripGitExtension("https://gerrit.example.com/myproject.git"),
+            "https://gerrit.example.com/myproject");
+        Assert.assertEquals(UrlUtils.stripGitExtension("https://gerrit.example.com/myproject.git/"),
+            "https://gerrit.example.com/myproject");
+        Assert.assertEquals(UrlUtils.stripGitExtension("ssh://gerrit.example.com:29418/tools/build.git"),
+            "ssh://gerrit.example.com:29418/tools/build");
+    }
+
+    @Test
+    public void testStripGitExtensionKeepsOtherOccurrences() throws Exception {
+        // ".git" in a host or project name is not an extension
+        Assert.assertEquals(UrlUtils.stripGitExtension("ssh://gerrit.gitlab.example.com:29418/tools/build"),
+            "ssh://gerrit.gitlab.example.com:29418/tools/build");
+        Assert.assertEquals(UrlUtils.stripGitExtension("https://review.example.com/a/my.github-actions.git"),
+            "https://review.example.com/a/my.github-actions");
+        Assert.assertEquals(UrlUtils.stripGitExtension("https://gerrit.example.com/myproject"),
+            "https://gerrit.example.com/myproject");
+    }
+
+    @Test
     public void testPatchSetDescriptionEncoding() throws Exception {
         String encoded = UrlUtils.encodePatchSetDescription("Abc %^@.~-+_:/!");
         Assert.assertEquals(encoded, "Abc+%25%5E%40%2E%7E%2D%2B%5F%3A%2F%21");


### PR DESCRIPTION
`UrlUtils.stripGitExtension()` was `url.replace(".git", "")` — every occurrence, not just the extension. Ran it:

```
ssh://gerrit.gitlab.example.com:29418/tools/build   -> ssh://gerritlab.example.com:29418/tools/build
https://review.example.com/a/my.github-actions.git  -> https://review.example.com/a/myhub-actions
```

The result is compared with the Gerrit url and with the project name of a change (`GerritUtil.getProjectNames`, `GerritUtil.getProjectName`, `GerritGitUtil.getRepositoryForGerritProject`), so a host or project containing `.git` — `.gitlab`, `.github`, `.gitignore` — made the plugin miss the repository: "No repository found for Gerrit project", and no changes for that project in the change list.

### Change

* remove the extension only where it is one
* handle a trailing slash while at it: `https://host/project.git/` became `https://host/project/` before, which did not match the project name either
* new test cases in `UrlUtilsTest` for both

https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR)_