### PR TITLE
Use the first proxy the IDE offers, not the last one

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/ProxyHttpClientBuilderExtension.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/rest/ProxyHttpClientBuilderExtension.java
@@ -62,8 +62,8 @@ public class ProxyHttpClientBuilderExtension extends HttpClientBuilderExtension 
                     AuthScope authScope = new AuthScope(proxySettings.PROXY_HOST, proxySettings.PROXY_PORT);
                     UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(proxySettings.getProxyLogin(), proxySettings.getPlainProxyPassword());
                     credentialsProvider.setCredentials(authScope, credentials);
-                    break;
                 }
+                break; // the first usable proxy is the one to use, the ones after it are the alternatives
             }
         }
         return credentialsProvider;


### PR DESCRIPTION
`ProxyHttpClientBuilderExtension` documents its loop as "Find the first real proxy with an address type we support", but it only left the loop inside the `PROXY_AUTHENTICATION` branch:

```java
if (HttpConfigurable.isRealProxy(proxy) && socketAddress instanceof InetSocketAddress) {
    ...
    httpClientBuilder.setProxy(proxyHttpHost);
    if (proxySettings.PROXY_AUTHENTICATION && proxySettings.getProxyLogin() != null) {
        ...
        break;
    }
}
```

Without proxy authentication — the common case — every further real proxy overwrote the one set before, so the **last** entry won. `IdeaWideProxySelector` returns the proxies in the order they should be tried (a PAC script says so explicitly), so the plugin ended up on the least preferred one.

### Change

Leave the loop after the first usable proxy, whether or not proxy credentials are configured.

https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR)_