### PR TITLE
Put a comment range which starts at a line start on that line

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/RangeUtils.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/RangeUtils.java
@@ -40,19 +40,23 @@ public final class RangeUtils {
             String lineString;
             int currentCharCount = 0;
             while ((lineString = reader.readLine()) != null) {
+                int lineStart = currentCharCount;
                 currentCharCount += lineString.length();
                 currentCharCount++; // line break
 
-                if (start > currentCharCount) {
+                // ">=": currentCharCount is the offset of the first character of the next line once the line break
+                // is counted, so a selection which starts there starts on that next line and not at the end of this one
+                if (start >= currentCharCount) {
                     startLine++;
                 } else if (startOffset < 0) {
-                    startOffset = start - (currentCharCount - lineString.length() - 1);
+                    startOffset = start - lineStart;
                 }
 
+                // the end stays at the end of the line it reaches: it is the line the comment gets attached to
                 if (end > currentCharCount) {
                     endLine++;
                 } else if (endOffset < 0) {
-                    endOffset = end - (currentCharCount - lineString.length() - 1);
+                    endOffset = end - lineStart;
                     break;
                 }
             }

--- a/src/test/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/RangeUtilsTest.java
+++ b/src/test/java/com/urswolfer/intellij/plugin/gerrit/ui/diff/RangeUtilsTest.java
@@ -45,6 +45,35 @@ public class RangeUtilsTest {
     }
 
     @Test
+    public void testTextOffsetToRangeStartingAtLineStart() throws Exception {
+        Comment.Range range = RangeUtils.textOffsetToRange(STRING, 16, 26); // line 2, selected as a whole line
+
+        Assert.assertEquals(2, range.startLine);
+        Assert.assertEquals(0, range.startCharacter);
+        Assert.assertEquals(2, range.endLine);
+        Assert.assertEquals(10, range.endCharacter);
+    }
+
+    @Test
+    public void testTextOffsetToRangeStartingAtTextStart() throws Exception {
+        Comment.Range range = RangeUtils.textOffsetToRange(STRING, 0, 5); // word "short"
+
+        Assert.assertEquals(1, range.startLine);
+        Assert.assertEquals(0, range.startCharacter);
+        Assert.assertEquals(1, range.endLine);
+        Assert.assertEquals(5, range.endCharacter);
+    }
+
+    @Test
+    public void testTextOffsetToRangeOfLineStartIsResolvedBack() throws Exception {
+        Comment.Range range = RangeUtils.textOffsetToRange(STRING, 16, 26);
+        RangeUtils.Offset offset = RangeUtils.rangeToTextOffset(STRING, range);
+
+        Assert.assertEquals(16, offset.start);
+        Assert.assertEquals(26, offset.end);
+    }
+
+    @Test
     public void testRangeToTextOffsetSingleLine() throws Exception {
         Comment.Range range = new Comment.Range();
         range.startLine = 2; // word "break"


### PR DESCRIPTION
`RangeUtils.textOffsetToRange()` advances to the next line only while `start > currentCharCount`. Once the line break is counted, `currentCharCount` *is* the offset of the next line's first character, so a selection starting exactly there stays on the line before it — and that is every selection of a whole line, the usual way to comment on code.

Reproduced by calling the class itself (`STRING = "short text with\nline break"`, selecting line 2):

```
select line 3 of a source file: offsets 34..48
  -> startLine=2 startChar=15      (line 2 is "    int a = 1;", 14 characters)
select "int b" inside the line:   offsets 38..43
  -> startLine=3 startChar=4       (correct, unaffected)
```

So Gerrit stores a range whose start lies at the end of the line *above* the selected one, and its web UI highlights from there. The plugin's own rendering hides it: `rangeToTextOffset()` uses the same convention, so the round trip returns the original offsets.

### Change

* compare against the offset of the next line's first character
* the end keeps its behaviour (it stays on the line it reaches, and `CommentForm` derives `comment.line` from it, so the comment stays attached to the same line)
* three test cases: a whole-line selection, a selection at the very start of the text, and the round trip of such a range

A range stored with the previous behaviour still resolves to the same text offsets, so existing comments keep rendering where they do today.

### Verification

`./gradlew test` — 7 tests in `RangeUtilsTest` (the 4 existing ones unchanged), 25 in total, all passing. `instrumentCode` cannot resolve its ant dependency in this sandbox and was skipped; it fails the same way on an unmodified checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR)_