### PR TITLE
Set up the push dialog when there is no push target yet

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
@@ -105,7 +105,9 @@ public class GerritPushExtensionPanel extends JPanel {
         SwingUtilities.invokeLater(new Runnable() {
             public void run() {
                 if (gerritPushTargetPanels.size() == 1) {
-                    String branchName = gerritPushTargetPanels.values().iterator().next();
+                    // the branch is null when the IDE has no push target for the repository (e.g. a detached head),
+                    // and Optional#or refuses a null default value
+                    String branchName = Strings.nullToEmpty(gerritPushTargetPanels.values().iterator().next());
                     Optional<String> gitReviewBranchName = getGitReviewBranchName();
                     branchTextField.setText(gitReviewBranchName.or(branchName));
                 }


### PR DESCRIPTION
`GerritPushExtensionPanel.initialized()` fills the branch field with

```java
String branchName = gerritPushTargetPanels.values().iterator().next();   // null when there is no default target
branchTextField.setText(gitReviewBranchName.or(branchName));
```

`GerritPushTargetPanel` registers `null` when the IDE hands it no default push target. Checked in the platform's `GitPushSupport.getDefaultTarget(GitRepository)`: it returns `null` for a repository without commits (`isFresh()`) and for a **detached head** (`getCurrentBranch() == null`) — the state `GerritPushTargetPanel` already deals with for the error the IDE sets ("an error which the IDE has set itself (e.g. for a detached head)").

Guava rejects a null default value. Verified against the Guava the platform ships (`ideaIC-2020.3.4/lib/guava-29.0-jre.jar`):

```
absent.or(null) threw: java.lang.NullPointerException: use Optional.orNull() instead of Optional.or(null)
present.or(null) threw: java.lang.NullPointerException: use Optional.orNull() instead of Optional.or(null)
```

Note the second line: a `.gitreview` file does not help, `Present#or` checks the default value as well. The exception is thrown inside the deferred runnable, so `initDestinationBranch()` — the next statement — never runs and no panel gets a `refs/for/…` target, not even with "push to Gerrit by default" enabled.

### Change

Fall back to an empty branch name; the ref is then built from the branch the panel itself carries, as it is for more than one repository.

https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR

---
_Generated by [Claude Code](https://claude.ai/code/session_01BEUSTw2N3YfKghGN5tSxFR)_