### PR TITLE
Handle push settings which cannot be part of the push reference

### DIFF
--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtension.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtension.java
@@ -108,6 +108,13 @@ public final class GerritPushExtension {
         }
     }
 
+    /**
+     * Copies the Gerrit plugin classes which take part in the push dialog into the Git plugin class loader.
+     *
+     * Every class used by one of them must be listed as well: the Git plugin class loader does not know the
+     * Gerrit plugin, so a class which is not copied ends up as a NoClassDefFoundError as soon as the copied
+     * code touches it.
+     */
     private static void copyGerritPluginClassesToGitPlugin(ClassPool classPool, ClassLoader targetClassLoader) {
         loadClass(classPool, targetClassLoader, "com.urswolfer.intellij.plugin.gerrit.push.GerritPushOptionsPanel");
         loadClass(classPool, targetClassLoader, "com.urswolfer.intellij.plugin.gerrit.push.GerritPushTargetPanel");
@@ -117,6 +124,7 @@ public final class GerritPushExtension {
         loadClass(classPool, targetClassLoader, "com.urswolfer.intellij.plugin.gerrit.push.GerritPushExtensionPanel$ChangeActionListener");
         loadClass(classPool, targetClassLoader, "com.urswolfer.intellij.plugin.gerrit.push.GerritPushExtensionPanel$ChangeTextActionListener");
         loadClass(classPool, targetClassLoader, "com.urswolfer.intellij.plugin.gerrit.push.GerritPushExtensionPanel$SettingsStateActionListener");
+        loadClass(classPool, targetClassLoader, "com.urswolfer.intellij.plugin.gerrit.push.PushOptionValidator");
         loadClass(classPool, targetClassLoader, "com.urswolfer.intellij.plugin.gerrit.util.UrlUtils");
     }
 

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushExtensionPanel.java
@@ -26,6 +26,7 @@ import com.intellij.ide.DataManager;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.project.Project;
+import com.intellij.ui.JBColor;
 import com.intellij.uiDesigner.core.GridConstraints;
 import com.intellij.uiDesigner.core.GridLayoutManager;
 import com.intellij.util.ui.UIUtil;
@@ -70,6 +71,7 @@ public class GerritPushExtensionPanel extends JPanel {
     private JTextField reviewersTextField;
     private JTextField ccTextField;
     private JTextField patchsetDescriptionTextField;
+    private JLabel validationLabel;
     private Map<GerritPushTargetPanel, String> gerritPushTargetPanels = Maps.newHashMap();
     private boolean initialized = false;
 
@@ -161,7 +163,7 @@ public class GerritPushExtensionPanel extends JPanel {
         pushToGerritCheckBox = new JCheckBox("Push to Gerrit");
         mainPanel.add(pushToGerritCheckBox);
 
-        indentedSettingPanel = new JPanel(new GridLayoutManager(13, 2));
+        indentedSettingPanel = new JPanel(new GridLayoutManager(14, 2));
 
         privateCheckBox = new JCheckBox("Private (Gerrit 2.15+)");
         privateCheckBox.setToolTipText("Push a private change or to turn a change private.");
@@ -201,17 +203,19 @@ public class GerritPushExtensionPanel extends JPanel {
 
         topicTextField = addTextField(
                 "Topic:",
-                "A short topic associated with all of the changes in the same group, such as the local topic branch name.",
+                "A short topic associated with all of the changes in the same group, such as the local topic branch name. " +
+                        "It must not contain spaces: Gerrit reads it from the push reference.",
                 8);
 
         hashTagTextField = addTextField(
                 "Hashtag (Gerrit 2.15+):",
-                "Include a hashtag associated with all of the changes in the same group.",
+                "Include a hashtag associated with all of the changes in the same group. " +
+                        "It must not contain spaces: Gerrit reads it from the push reference.",
                 9);
 
         patchsetDescriptionTextField = addTextField(
                 "Patch Set Description (Gerrit 3.4+):",
-                "A description of the patch set to be created. Intended to help guide reviewers as a change evolves. The description cannot be changed after the change is pushed.",
+                "A description of the patch set to be created. Intended to help guide reviewers as a change evolves. The description cannot be changed after the change is pushed. Spaces can be used: the description is encoded before it is added to the push reference.",
                 10);
 
         reviewersTextField = addTextField(
@@ -223,6 +227,18 @@ public class GerritPushExtensionPanel extends JPanel {
                 "CC (user names, comma separated):",
                 "Users which will receive carbon copies of the notification message.",
                 12);
+
+        validationLabel = new JLabel();
+        validationLabel.setForeground(JBColor.RED);
+        indentedSettingPanel.add(
+                validationLabel,
+                new GridConstraints(13, 0, 1, 2,
+                        GridConstraints.ANCHOR_WEST,
+                        GridConstraints.FILL_NONE,
+                        GridConstraints.SIZEPOLICY_CAN_GROW,
+                        GridConstraints.SIZEPOLICY_FIXED,
+                        null, null, null)
+        );
 
         final JPanel settingLayoutPanel = new JPanel();
         settingLayoutPanel.setAlignmentX(Component.LEFT_ALIGNMENT);
@@ -285,9 +301,14 @@ public class GerritPushExtensionPanel extends JPanel {
     /**
      * Builds the push target ref for the provided branch.
      *
-     * The values entered by the user (branch, topic, patch set description, ...) are appended as they are.
-     * They must never be handled as a format string: the patch set description is percent-encoded, and
-     * sequences like "%2E" would be interpreted as (invalid) format specifiers.
+     * The values entered by the user (branch, topic, patch set description, ...) are appended as they are,
+     * apart from surrounding whitespace which gets trimmed. They must never be handled as a format string:
+     * the patch set description is percent-encoded, and sequences like "%2E" would be interpreted as
+     * (invalid) format specifiers.
+     *
+     * Values which cannot be transported in a ref (e.g. a topic containing a space) are added nevertheless:
+     * the push target is marked as invalid in that case, which stops the push from happening with a ref
+     * which does not contain what the user entered. See {@link #validateSettings()}.
      */
     private String getRef(String branch) {
         StringBuilder ref = new StringBuilder();
@@ -299,8 +320,9 @@ public class GerritPushExtensionPanel extends JPanel {
         } else {
             ref.append("refs/for/");
         }
-        if (!branchTextField.getText().isEmpty()) {
-            ref.append(branchTextField.getText());
+        String branchName = getTrimmedText(branchTextField);
+        if (!branchName.isEmpty()) {
+            ref.append(branchName);
         } else {
             ref.append(branch);
         }
@@ -321,14 +343,17 @@ public class GerritPushExtensionPanel extends JPanel {
         if (submitChangeCheckBox.isSelected()) {
             gerritSpecs.add("submit");
         }
-        if (!topicTextField.getText().isEmpty()) {
-            gerritSpecs.add("topic=" + topicTextField.getText());
+        String topic = getTrimmedText(topicTextField);
+        if (!topic.isEmpty()) {
+            gerritSpecs.add("topic=" + topic);
         }
-        if (!hashTagTextField.getText().isEmpty()) {
-            gerritSpecs.add("hashtag=" + hashTagTextField.getText());
+        String hashTag = getTrimmedText(hashTagTextField);
+        if (!hashTag.isEmpty()) {
+            gerritSpecs.add("hashtag=" + hashTag);
         }
-        if (!patchsetDescriptionTextField.getText().isEmpty()) {
-            gerritSpecs.add("m=" + UrlUtils.encodePatchSetDescription(patchsetDescriptionTextField.getText()));
+        String patchsetDescription = getTrimmedText(patchsetDescriptionTextField);
+        if (!patchsetDescription.isEmpty()) {
+            gerritSpecs.add("m=" + UrlUtils.encodePatchSetDescription(patchsetDescription));
         }
         handleCommaSeparatedUserNames(gerritSpecs, reviewersTextField, "r");
         handleCommaSeparatedUserNames(gerritSpecs, ccTextField, "cc");
@@ -353,15 +378,90 @@ public class GerritPushExtensionPanel extends JPanel {
         }
     }
 
+    /**
+     * Returns the content of a text field without surrounding whitespace: it would end up in the push ref,
+     * where it cannot be used.
+     */
+    private static String getTrimmedText(JTextField textField) {
+        return PushOptionValidator.trim(textField.getText());
+    }
+
+    /**
+     * Checks all values which are added to the push ref, marks the invalid ones and shows a message for the
+     * first of them. The message is returned as well: it is handed to the push target panels, which do not
+     * accept a ref built out of such a value.
+     */
+    private String validateSettings() {
+        String error = null;
+        if (pushToGerritCheckBox.isSelected()) {
+            error = firstError(
+                    validateBranch(branchTextField),
+                    validateOption(topicTextField, "Topic"),
+                    validateOption(hashTagTextField, "Hashtag"),
+                    validateUserNames(reviewersTextField, "Reviewer name"),
+                    validateUserNames(ccTextField, "CC user name"));
+        } else {
+            for (JTextField textField : Lists.newArrayList(branchTextField, topicTextField, hashTagTextField,
+                    reviewersTextField, ccTextField)) {
+                markInvalid(textField, false);
+            }
+        }
+        validationLabel.setText(Strings.nullToEmpty(error));
+        return error;
+    }
+
+    private String validateBranch(JTextField textField) {
+        String branch = getTrimmedText(textField);
+        String error = PushOptionValidator.validateBranch("Branch", branch);
+        // a branch which cannot be part of a ref name (e.g. "release/") is reported by the push target;
+        // mark the field it comes from, but leave the message to the push target
+        markInvalid(textField, error != null || !PushOptionValidator.isUsableAsBranchName(branch));
+        return error;
+    }
+
+    private String validateOption(JTextField textField, String label) {
+        String error = PushOptionValidator.validateOption(label, getTrimmedText(textField));
+        markInvalid(textField, error != null);
+        return error;
+    }
+
+    private String validateUserNames(JTextField textField, String label) {
+        String error = null;
+        for (String item : COMMA_SPLITTER.split(textField.getText())) {
+            error = firstError(error, PushOptionValidator.validateOption(label, item));
+        }
+        markInvalid(textField, error != null);
+        return error;
+    }
+
+    private static String firstError(String... errors) {
+        for (String error : errors) {
+            if (error != null) {
+                return error;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Marks a text field with the error outline of the current IDE theme, or removes that marking again.
+     */
+    private static void markInvalid(JComponent component, boolean invalid) {
+        component.putClientProperty("JComponent.outline", invalid ? "error" : null);
+        component.repaint();
+    }
+
     private void initDestinationBranch() {
+        String settingsError = validateSettings();
         for (Map.Entry<GerritPushTargetPanel, String> entry : gerritPushTargetPanels.entrySet()) {
-            entry.getKey().initBranch(getRef(entry.getValue()), pushToGerritByDefault);
+            entry.getKey().initBranch(getRef(entry.getValue()), pushToGerritByDefault, settingsError);
         }
     }
 
     private void updateDestinationBranch() {
+        String settingsError = validateSettings();
         for (Map.Entry<GerritPushTargetPanel, String> entry : gerritPushTargetPanels.entrySet()) {
-            entry.getKey().updateBranch(getRef(entry.getValue()));
+            entry.getKey().updateBranch(getRef(entry.getValue()), settingsError);
         }
     }
 

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushTargetPanel.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/GerritPushTargetPanel.java
@@ -60,8 +60,8 @@ public class GerritPushTargetPanel extends GitPushTargetPanel {
         gerritPushOptionsPanel.getGerritPushExtensionPanel().registerGerritPushTargetPanel(this, initialBranch);
     }
 
-    public void initBranch(final String branch, boolean pushToGerritByDefault) {
-        setBranch(branch);
+    public void initBranch(final String branch, boolean pushToGerritByDefault, String settingsError) {
+        setBranch(branch, settingsError);
         try {
             Field myFireOnChangeActionField = getField("myFireOnChangeAction");
             final Runnable myFireOnChangeAction = (Runnable) myFireOnChangeActionField.get(this);
@@ -94,11 +94,11 @@ public class GerritPushTargetPanel extends GitPushTargetPanel {
         } catch (IllegalAccessException e) {
             LOG.error(e);
         }
-        updateBranch(branch);
+        updateBranch(branch, settingsError);
     }
 
-    public void updateBranch(String branch) {
-        setBranch(branch);
+    public void updateBranch(String branch, String settingsError) {
+        setBranch(branch, settingsError);
         try {
             Field myFireOnChangeActionField = getField("myFireOnChangeAction");
             Runnable myFireOnChangeAction = (Runnable) myFireOnChangeActionField.get(this);
@@ -159,9 +159,16 @@ public class GerritPushTargetPanel extends GitPushTargetPanel {
         return field;
     }
 
-    public void setBranch(String branch) {
+    /**
+     * Sets the ref to push to, or marks the push target as invalid when it cannot be used.
+     *
+     * {@code settingsError} reports a Gerrit push setting which cannot be transported in the ref. Such a ref is a
+     * valid ref name, so it would be pushed - and Gerrit would read something else than what was entered (e.g.
+     * "refs/for/mas%ter" pushes to branch "mas" with a push option "ter").
+     */
+    private void setBranch(String branch, String settingsError) {
         String trimmedBranch = branch == null ? "" : branch.trim();
-        if (GitRefNameValidator.getInstance().checkInput(trimmedBranch)) {
+        if (settingsError == null && GitRefNameValidator.getInstance().checkInput(trimmedBranch)) {
             this.branch = trimmedBranch;
             setError(null);
             return;
@@ -171,6 +178,6 @@ public class GerritPushTargetPanel extends GitPushTargetPanel {
         // still typing a branch name (e.g. "refs/for/release/" on the way to "refs/for/release/1.0"). Mark the push
         // target as invalid instead of leaving a branch name behind which would not be the one pushed to.
         this.branch = null;
-        setError("Invalid destination branch name: " + trimmedBranch);
+        setError(settingsError != null ? settingsError : "Invalid destination branch name: " + trimmedBranch);
     }
 }

--- a/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/PushOptionValidator.java
+++ b/src/main/java/com/urswolfer/intellij/plugin/gerrit/push/PushOptionValidator.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2013-2014 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.urswolfer.intellij.plugin.gerrit.push;
+
+import com.google.common.base.CharMatcher;
+import git4idea.validators.GitRefNameValidator;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Checks the values entered in the Gerrit push settings for what cannot be transported in the Git
+ * reference the commits are pushed to (e.g. "refs/for/master%topic=my-topic"). Gerrit reads them
+ * from that reference without decoding them; the patch set description is the only exception, see
+ * {@link com.urswolfer.intellij.plugin.gerrit.util.UrlUtils#encodePatchSetDescription(String)}.
+ *
+ * Characters which are invalid in a reference name are already rejected by the push target panel,
+ * which validates the assembled reference with git4idea. Only the cases it cannot report properly
+ * are handled here: whitespace (what users actually run into, and the reference name error does not
+ * tell which of the values caused it), and the two characters which Git accepts but Gerrit reads as
+ * syntax of the reference.
+ */
+public class PushOptionValidator {
+
+    private static final CharMatcher WHITESPACE = CharMatcher.whitespace();
+
+    /** A comma separates the Gerrit push options from each other. */
+    private static final CharMatcher INVALID_OPTION_CHARS = WHITESPACE.or(CharMatcher.is(','));
+
+    /** Gerrit handles everything after the first percent sign of a reference as push options. */
+    private static final CharMatcher INVALID_BRANCH_CHARS = WHITESPACE.or(CharMatcher.is('%'));
+
+    private PushOptionValidator() {}
+
+    /**
+     * Removes the whitespace which this class rejects from both ends of a value. String#trim() is not
+     * enough: it stops at U+0020, which would leave e.g. a pasted no-break space to be rejected instead
+     * of being trimmed away.
+     */
+    public static String trim(String value) {
+        return WHITESPACE.trimFrom(value);
+    }
+
+    /**
+     * Returns an error message for the push destination branch, or {@code null} if it can be used.
+     */
+    @Nullable
+    public static String validateBranch(String label, String value) {
+        return validate(label, value, INVALID_BRANCH_CHARS);
+    }
+
+    /**
+     * Returns an error message for a push option value (topic, hashtag, user name, ...), or
+     * {@code null} if it can be used.
+     */
+    @Nullable
+    public static String validateOption(String label, String value) {
+        return validate(label, value, INVALID_OPTION_CHARS);
+    }
+
+    /**
+     * Tells whether the branch can be part of a ref name. An empty value can: the branch of the push
+     * target is used then.
+     *
+     * What this rejects (e.g. a branch ending with a slash) is reported by the push target itself, which
+     * validates the assembled ref - it just does not tell which of the values it is caused by.
+     */
+    public static boolean isUsableAsBranchName(String value) {
+        return value.isEmpty() || GitRefNameValidator.getInstance().checkInput(value);
+    }
+
+    @Nullable
+    private static String validate(String label, String value, CharMatcher invalidChars) {
+        int index = invalidChars.indexIn(value);
+        if (index < 0) {
+            return null;
+        }
+        char invalidChar = value.charAt(index);
+        if (WHITESPACE.matches(invalidChar)) {
+            // name the character for whitespace which cannot be seen in the text field
+            String whitespace = invalidChar == ' ' ? "spaces" : String.format("whitespace (U+%04X)", (int) invalidChar);
+            return label + " must not contain " + whitespace + " (Gerrit reads it from the push reference, "
+                + "and Git reference names cannot contain spaces).";
+        }
+        return label + " must not contain the character '" + invalidChar + "'.";
+    }
+}

--- a/src/test/java/com/urswolfer/intellij/plugin/gerrit/push/PushOptionValidatorTest.java
+++ b/src/test/java/com/urswolfer/intellij/plugin/gerrit/push/PushOptionValidatorTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2013-2014 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.urswolfer.intellij.plugin.gerrit.push;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class PushOptionValidatorTest {
+
+    @Test
+    public void testEmptyValueIsValid() throws Exception {
+        Assert.assertNull(PushOptionValidator.validateOption("Topic", ""));
+        Assert.assertNull(PushOptionValidator.validateBranch("Branch", ""));
+    }
+
+    @Test
+    public void testTopicWithSlashIsValid() throws Exception {
+        Assert.assertNull(PushOptionValidator.validateOption("Topic", "driver/i42"));
+    }
+
+    @Test
+    public void testTopicWithSpace() throws Exception {
+        String error = PushOptionValidator.validateOption("Topic", "Bug xy");
+        Assert.assertNotNull(error);
+        Assert.assertTrue(error.startsWith("Topic must not contain spaces"), error);
+    }
+
+    @Test
+    public void testTopicWithTab() throws Exception {
+        // whitespace which cannot be seen in the text field is named
+        String error = PushOptionValidator.validateOption("Topic", "Bug\txy");
+        Assert.assertNotNull(error);
+        Assert.assertTrue(error.startsWith("Topic must not contain whitespace (U+0009)"), error);
+    }
+
+    @Test
+    public void testTopicWithNoBreakSpace() throws Exception {
+        String error = PushOptionValidator.validateOption("Topic", "Bug\u00A0xy");
+        Assert.assertNotNull(error);
+        Assert.assertTrue(error.startsWith("Topic must not contain whitespace (U+00A0)"), error);
+    }
+
+    @Test
+    public void testTrimRemovesWhatIsRejected() throws Exception {
+        // String#trim() stops at U+0020 and would leave these to be rejected instead of trimmed away
+        Assert.assertEquals(PushOptionValidator.trim("\u00A0 my-topic \u3000"), "my-topic");
+        Assert.assertNull(PushOptionValidator.validateOption("Topic", PushOptionValidator.trim(" my-topic ")));
+    }
+
+    @Test
+    public void testTopicWithComma() throws Exception {
+        // a comma would be handled as separator between two Gerrit push options
+        Assert.assertEquals(PushOptionValidator.validateOption("Topic", "bug,fix"),
+            "Topic must not contain the character ','.");
+    }
+
+    @Test
+    public void testTopicWithCharacterWhichIsInvalidInRefName() throws Exception {
+        // characters which cannot be part of a ref name are rejected by the push target panel,
+        // which validates the assembled ref
+        Assert.assertNull(PushOptionValidator.validateOption("Topic", "bug~1"));
+    }
+
+    @Test
+    public void testTopicWithPercentSignIsValid() throws Exception {
+        // only the first percent sign separates the branch name from the push options
+        Assert.assertNull(PushOptionValidator.validateOption("Topic", "50%done"));
+    }
+
+    @Test
+    public void testBranchWithPercentSign() throws Exception {
+        // Gerrit handles everything after the first percent sign as push options
+        Assert.assertEquals(PushOptionValidator.validateBranch("Branch", "mas%ter"),
+            "Branch must not contain the character '%'.");
+    }
+
+    @Test
+    public void testBranchWithSlashIsValid() throws Exception {
+        Assert.assertNull(PushOptionValidator.validateBranch("Branch", "release/1.0"));
+    }
+
+    @Test
+    public void testBranchWithCommaIsValid() throws Exception {
+        // only the push options are separated by commas; the branch name is read up to the first
+        // percent sign
+        Assert.assertNull(PushOptionValidator.validateBranch("Branch", "fea,ture"));
+    }
+
+    @Test
+    public void testUsableAsBranchName() throws Exception {
+        Assert.assertTrue(PushOptionValidator.isUsableAsBranchName(""));
+        Assert.assertTrue(PushOptionValidator.isUsableAsBranchName("release/1.0"));
+    }
+
+    @Test
+    public void testBranchEndingWithSlashIsNotUsable() throws Exception {
+        // happens while a branch name is typed; the push target reports it
+        Assert.assertFalse(PushOptionValidator.isUsableAsBranchName("release/"));
+    }
+
+    @Test
+    public void testUserNameWithSpace() throws Exception {
+        String error = PushOptionValidator.validateOption("Reviewer name", "John Doe");
+        Assert.assertNotNull(error);
+        Assert.assertTrue(error.startsWith("Reviewer name must not contain spaces"), error);
+    }
+
+    @Test
+    public void testMailAddressIsValid() throws Exception {
+        Assert.assertNull(PushOptionValidator.validateOption("Reviewer name", "john.doe@example.com"));
+    }
+}


### PR DESCRIPTION
Fixes #405.

Gerrit reads topic, hashtag and user names from the push reference without decoding them (only the patch set description is decoded, [ReceiveCommits](https://github.com/GerritCodeReview/gerrit/blob/master/java/com/google/gerrit/server/git/receive/ReceiveCommits.java#L2020)), so a topic like `Bug xy` cannot be transported at all - a Git reference name must not contain spaces. The panel built such a reference anyway: the push target showed an error without telling which setting caused it.

* Values are checked for whitespace and for the two characters Git accepts but Gerrit reads as reference syntax: a comma between push options, and a percent sign in the branch name. The setting and the character are named below the fields, the field is marked, and the push target is not usable while a value is invalid. The latter two produce a valid reference name, so nothing stopped them before - a branch `mas%ter` pushed to branch `mas` with a push option `ter`.
* Everything else stays with the push target, which validates the assembled reference. A branch it rejects (e.g. `release/`) now marks the branch field too, so that error can be traced back to a setting.
* Surrounding whitespace is trimmed instead of rejected - it is regularly pasted along with a value and went into the reference before. Trimming uses the same definition of whitespace as the check, so a pasted no-break space is trimmed away rather than reported.

`PushOptionValidator` is copied into the Git plugin class loader like `UrlUtils`; without that entry the panel dies with a `NoClassDefFoundError` on the first keystroke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W32FN8tahEFH4ghjK6vF1a