### PR TITLE
Bump version to 2.0.0-203

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 ideaVersion=IC-2020.3.4
 ijPluginRepoChannel=
 downloadIdeaSources=false
-version=1.3.4-203
+version=2.0.0-203
 javaVersion=11

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -90,6 +90,17 @@
           href="https://github.com/uwolfer/gerrit-intellij-plugin#pre-releases">
           https://github.com/uwolfer/gerrit-intellij-plugin#pre-releases</a>.</li>
 
+          <li>2.0.0</li>
+          <ul>
+            <li>large parts of the internals have been rewritten (dependency injection, background loading, notifications);
+            please report anything which behaves differently than before</li>
+            <li>migrate off deprecated and internal IntelliJ API</li>
+            <li>fix checkout and fetch of changes under WSL2</li>
+            <li>escape comment text before it is rendered</li>
+            <li>several push dialog fixes (invalid branch names, missing push target, push settings handling)</li>
+            <li>load changes and comment counts without blocking the IDE</li>
+            <li>fix percent-encoding of filter queries and patch set descriptions</li>
+          </ul>
           <li>1.3.4</li>
           <ul>
             <li>fix Gerrit credentials not being persisted when using KeePass as the password backend</li>


### PR DESCRIPTION
Prepares the 2.0.0-203 release: bumps `version` in `gradle.properties` and adds the 2.0.0 section to the change notes in `plugin.xml`.

123 commits landed since v1.3.4-203, most of them internal (Guice replaced with the platform's own services, migrations off deprecated and internal API, threading and notification rework), so the notes lead with that and ask for reports of behaviour changes.

Tagging `v2.0.0-203` after this is merged triggers the release workflow (GitHub release + `publishPlugin`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wBKT9qJEERbxxdsnD3caj

---
_Generated by [Claude Code](https://claude.ai/code/session_015wBKT9qJEERbxxdsnD3caj)_